### PR TITLE
feat: initialize .NET user secrets for sensitive configuration

### DIFF
--- a/src/Aarogya.Api/Aarogya.Api.csproj
+++ b/src/Aarogya.Api/Aarogya.Api.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Aarogya.Api</RootNamespace>
+    <UserSecretsId>b7198fda-64cf-49d7-887a-870e4ba95b96</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -4,7 +4,7 @@
     "Redis": "localhost:6379,abortConnect=false,connectTimeout=5000"
   },
   "Jwt": {
-    "Key": "REPLACE_VIA_USER_SECRETS",
+    "Key": "SET_VIA_USER_SECRETS_OR_ENV_VAR",
     "Issuer": "AarogyaAPI",
     "Audience": "AarogyaClients",
     "ExpiryInMinutes": 120

--- a/src/Aarogya.Api/secrets.template.json
+++ b/src/Aarogya.Api/secrets.template.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Copy this structure to set up .NET user secrets. Run: dotnet user-secrets set 'Key:SubKey' 'value' --project src/Aarogya.Api",
+
+  "Jwt:Key": "your-secret-key-minimum-32-characters-long-for-hmac",
+
+  "ConnectionStrings:DefaultConnection": "Host=localhost;Port=5432;Database=aarogya;Username=aarogya;Password=your_password;Include Error Detail=true",
+
+  "Aws:AccessKey": "your-aws-access-key-or-test-for-localstack",
+  "Aws:SecretKey": "your-aws-secret-key-or-test-for-localstack",
+
+  "Redis:Password": ""
+}


### PR DESCRIPTION
## Summary
- Initialized .NET user secrets for the `Aarogya.Api` project
- Created `secrets.template.json` documenting all required secret keys
- Updated `appsettings.Development.json` to clarify JWT key source

## Changes

### User Secrets Initialized
`UserSecretsId` added to `Aarogya.Api.csproj` — enables `dotnet user-secrets` for local dev. Secrets are stored in `~/.microsoft/usersecrets/` outside the repo, never committed.

### secrets.template.json
Documents the required secrets with example values:

| Secret Key | Purpose |
|-----------|---------|
| `Jwt:Key` | JWT signing key (min 32 chars for HMAC) |
| `ConnectionStrings:DefaultConnection` | PostgreSQL connection string |
| `Aws:AccessKey` | AWS access key (or `test` for LocalStack) |
| `Aws:SecretKey` | AWS secret key (or `test` for LocalStack) |
| `Redis:Password` | Redis auth password (empty for local dev) |

### Developer Setup
```bash
# Initialize (already done — UserSecretsId is in csproj)
dotnet user-secrets set "Jwt:Key" "your-secret-key-minimum-32-characters-long" --project src/Aarogya.Api
dotnet user-secrets set "Aws:AccessKey" "test" --project src/Aarogya.Api
dotnet user-secrets set "Aws:SecretKey" "test" --project src/Aarogya.Api
```

## Test plan
- [x] `dotnet user-secrets list --project src/Aarogya.Api` shows all secrets
- [x] `dotnet build` succeeds
- [x] No sensitive data in committed files

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)