### PR TITLE
feat: configure AWS services settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,21 @@ JWT_ISSUER=AarogyaAPI
 JWT_AUDIENCE=AarogyaClients
 
 # --- AWS (use 'test' values for LocalStack) -----------------------------------
+# Credentials — set via user-secrets locally; IAM roles in production
 # AWS_ACCESS_KEY=test
 # AWS_SECRET_KEY=test
 # AWS_REGION=ap-south-1
 # AWS_SERVICE_URL=http://localstack:4566
+# AWS_USE_LOCALSTACK=true
+#
+# S3 — bucket naming: aarogya-{env} (e.g. aarogya-dev, aarogya-staging, aarogya-prod)
+# AWS_S3_BUCKET_NAME=aarogya-dev
+# AWS_S3_PRESIGNED_URL_EXPIRY_MINUTES=60
+# AWS_S3_DEFAULT_ACL=private
+#
+# SES — sender must be verified in SES console
+# AWS_SES_SENDER_EMAIL=noreply@aarogya.dev
+# AWS_SES_SENDER_NAME=Aarogya
 
 # --- Redis --------------------------------------------------------------------
 # REDIS_PASSWORD=

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="AWSSDK.S3" Version="3.7.401.26" />
+    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.22" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.18.6" />
+    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.11.5" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentValidation" Version="11.9.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />

--- a/src/Aarogya.Api/Configuration/AwsOptions.cs
+++ b/src/Aarogya.Api/Configuration/AwsOptions.cs
@@ -30,6 +30,11 @@ public sealed class S3Options
 
   [Range(1, 10080)]
   public int PresignedUrlExpiryMinutes { get; set; } = 60;
+
+  /// <summary>
+  /// Default object access: "private" or "public-read".
+  /// </summary>
+  public string DefaultAcl { get; set; } = "private";
 }
 
 public sealed class SesOptions

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -15,7 +15,8 @@
     "UseLocalStack": true,
     "S3": {
       "BucketName": "aarogya-dev",
-      "PresignedUrlExpiryMinutes": 60
+      "PresignedUrlExpiryMinutes": 60,
+      "DefaultAcl": "private"
     },
     "Ses": {
       "SenderEmail": "noreply@aarogya.dev",

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -18,6 +18,19 @@
   "ConnectionStrings": {
     "DefaultConnection": "SET_VIA_USER_SECRETS_OR_ENV_VAR"
   },
+  "Aws": {
+    "Region": "ap-south-1",
+    "UseLocalStack": false,
+    "S3": {
+      "BucketName": "SET_VIA_ENV_VAR",
+      "PresignedUrlExpiryMinutes": 60,
+      "DefaultAcl": "private"
+    },
+    "Ses": {
+      "SenderEmail": "SET_VIA_ENV_VAR",
+      "SenderName": "Aarogya"
+    }
+  },
   "Database": {
     "CommandTimeoutSeconds": 30,
     "EnableDetailedErrors": false,

--- a/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
+++ b/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" />
+    <PackageReference Include="AWSSDK.S3" />
+    <PackageReference Include="AWSSDK.SimpleEmailV2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
+++ b/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
@@ -1,0 +1,74 @@
+using Amazon;
+using Amazon.Extensions.NETCore.Setup;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.SimpleEmailV2;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aarogya.Infrastructure.Aws;
+
+public static class AwsServiceRegistration
+{
+  public static IServiceCollection AddAwsServices(
+    this IServiceCollection services,
+    IConfiguration configuration)
+  {
+    ArgumentNullException.ThrowIfNull(configuration);
+
+    var awsSection = configuration.GetSection("Aws");
+    var region = awsSection["Region"] ?? "ap-south-1";
+    var serviceUrl = awsSection["ServiceUrl"];
+    var useLocalStack = awsSection.GetSection("UseLocalStack").Get<bool?>() ?? false;
+    var accessKey = awsSection["AccessKey"] ?? string.Empty;
+    var secretKey = awsSection["SecretKey"] ?? string.Empty;
+
+    var awsOptions = new AWSOptions
+    {
+      Region = RegionEndpoint.GetBySystemName(region)
+    };
+
+    // Use explicit credentials when provided (LocalStack or non-IAM environments)
+    if (!string.IsNullOrWhiteSpace(accessKey) && !string.IsNullOrWhiteSpace(secretKey))
+    {
+      awsOptions.Credentials = new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    services.AddDefaultAWSOptions(awsOptions);
+
+    // Register S3 client
+    if (useLocalStack && !string.IsNullOrWhiteSpace(serviceUrl))
+    {
+      services.AddSingleton<IAmazonS3>(_ => new AmazonS3Client(
+        awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
+        new AmazonS3Config
+        {
+          RegionEndpoint = awsOptions.Region,
+          ServiceURL = serviceUrl,
+          ForcePathStyle = true
+        }));
+    }
+    else
+    {
+      services.AddAWSService<IAmazonS3>();
+    }
+
+    // Register SES v2 client
+    if (useLocalStack && !string.IsNullOrWhiteSpace(serviceUrl))
+    {
+      services.AddSingleton<IAmazonSimpleEmailServiceV2>(_ => new AmazonSimpleEmailServiceV2Client(
+        awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
+        new AmazonSimpleEmailServiceV2Config
+        {
+          RegionEndpoint = awsOptions.Region,
+          ServiceURL = serviceUrl
+        }));
+    }
+    else
+    {
+      services.AddAWSService<IAmazonSimpleEmailServiceV2>();
+    }
+
+    return services;
+  }
+}

--- a/src/Aarogya.Infrastructure/DependencyInjection.cs
+++ b/src/Aarogya.Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using Aarogya.Infrastructure.Aws;
 using Aarogya.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -58,6 +59,9 @@ public static class DependencyInjection
     // Register a health check for PostgreSQL
     services.AddHealthChecks()
       .AddDbContextCheck<AarogyaDbContext>("postgresql", tags: ["db", "ready"]);
+
+    // Register AWS services (S3, SES)
+    services.AddAwsServices(configuration);
 
     return services;
   }


### PR DESCRIPTION
## Summary
- Register `IAmazonS3` and `IAmazonSimpleEmailServiceV2` in DI via `AwsServiceRegistration`, with automatic LocalStack detection (custom `ServiceURL`, `ForcePathStyle` for S3)
- Add `AWSSDK.Extensions.NETCore.Setup` and `AWSSDK.SimpleEmailV2` packages; upgrade `AWSSDK.S3` from v3.7 to v4.0 for .NET 9 compatibility
- Add `DefaultAcl` property to `S3Options` for controlling S3 object access (private/public-read)
- Add base AWS section to `appsettings.json` with production defaults
- Document AWS resource naming conventions (`aarogya-{env}`) and SES sender verification in `.env.example`

## Test plan
- [ ] Verify `dotnet build` succeeds with no errors
- [ ] Verify `dotnet format --verify-no-changes` passes
- [ ] Verify `dotnet test` passes
- [ ] Verify `IAmazonS3` and `IAmazonSimpleEmailServiceV2` resolve from DI in Development
- [ ] Verify LocalStack configuration creates clients with custom `ServiceURL`

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)