### PR TITLE
feat: implement configuration validation and security checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "pre-commit: ripgrep (rg) is required to scan for secrets."
+  exit 1
+fi
+
+readonly ALLOWED_FILE_REGEX='(secrets\.template\.json|\.env\.example|README\.md)$'
+readonly SECRET_REGEX='(AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|-----BEGIN( [A-Z]+)? PRIVATE KEY-----|(?i)(aws|sonar|jwt).{0,24}(secret|token|key).{0,8}[:=].{0,4}[A-Za-z0-9_\/+=.-]{16,})'
+
+has_issues=0
+
+while IFS= read -r file; do
+  [[ -z "${file}" ]] && continue
+
+  if [[ "${file}" =~ ${ALLOWED_FILE_REGEX} ]]; then
+    continue
+  fi
+
+  if git show ":${file}" | rg -n -e "${SECRET_REGEX}" >/dev/null; then
+    echo "pre-commit: potential secret detected in staged file '${file}'."
+    has_issues=1
+  fi
+done < <(git diff --cached --name-only --diff-filter=ACM)
+
+if [[ ${has_issues} -eq 1 ]]; then
+  echo "pre-commit: commit blocked. Remove secrets or move them to user-secrets/environment variables."
+  exit 1
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -89,9 +89,14 @@ TestResult.xml
 
 # Environment variables and secrets
 .env
+.env.*
+.envrc
 .env.local
 .env.production
+.env.example
+!.env.example
 appsettings.Local.json
+appsettings.*.local.json
 appsettings.Production.json
 appsettings.Staging.json
 !src/Aarogya.Api/appsettings.Production.json
@@ -120,6 +125,8 @@ secrets.json
 
 # Local agent worktree metadata
 .claude/worktrees/
+.sonar/
+.sonarqube/
 
 # Windows
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -346,6 +346,26 @@ Current PR checks:
 
 See `/docs/github-main-guardrails.md` for full guardrail and ruleset setup details.
 
+## 🔒 Configuration Security
+
+Configuration validation runs at startup and enforces:
+- required keys (`ConnectionStrings:DefaultConnection`, `Jwt:Key`)
+- secure JWT key length
+- secure connection string values (non-default credentials in non-development environments)
+- valid URL formats for configurable endpoints (for example `Aws:ServiceUrl`, CORS origins)
+
+Sensitive configuration guidance:
+- keep secrets in user-secrets or environment variables, not committed JSON files
+- use placeholder values only in templates (`secrets.template.json`, `.env.example`)
+- prefer `AAROGYA_`-prefixed environment variables in deployed environments
+
+Install local git hooks to prevent accidental secret commits:
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The pre-commit hook scans staged files for common secret patterns and blocks unsafe commits.
+
 ## 🐛 Troubleshooting
 
 ### Port already in use

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+chmod +x "${repo_root}/.githooks/pre-commit"
+git -C "${repo_root}" config core.hooksPath .githooks
+
+echo "Git hooks installed. core.hooksPath is set to .githooks"

--- a/src/Aarogya.Api/Configuration/StartupExtensions.cs
+++ b/src/Aarogya.Api/Configuration/StartupExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Serilog;
 using Serilog.Events;
 
@@ -71,25 +72,18 @@ public static class StartupExtensions
 
   public static void ValidateRequiredConfiguration(IConfiguration configuration, IHostEnvironment environment)
   {
-    var missingKeys = new List<string>();
+    var violations = new List<string>();
 
-    if (string.IsNullOrWhiteSpace(configuration["ConnectionStrings:DefaultConnection"]))
-    {
-      missingKeys.Add("ConnectionStrings:DefaultConnection");
-    }
+    violations.AddRange(GetMissingRequiredConfiguration(configuration));
+    violations.AddRange(GetSecurityConfigurationViolations(configuration, environment));
 
-    var jwtKeyValue = configuration["Jwt:Key"];
-    if (string.IsNullOrWhiteSpace(jwtKeyValue) || jwtKeyValue == "SET_VIA_USER_SECRETS_OR_ENV_VAR")
-    {
-      missingKeys.Add("Jwt:Key");
-    }
-
-    if (missingKeys.Count <= 0)
+    var joinedViolations = string.Join("; ", violations);
+    if (string.IsNullOrWhiteSpace(joinedViolations))
     {
       return;
     }
 
-    var message = $"Missing required configuration: {string.Join(", ", missingKeys)}. "
+    var message = $"Invalid configuration: {joinedViolations}. "
       + "Set via user-secrets, environment variables (prefix AAROGYA_), or appsettings.";
 
     if (environment.IsDevelopment())
@@ -100,5 +94,81 @@ public static class StartupExtensions
     {
       throw new InvalidOperationException(message);
     }
+  }
+
+  private static List<string> GetMissingRequiredConfiguration(IConfiguration configuration)
+  {
+    var violations = new List<string>();
+
+    if (string.IsNullOrWhiteSpace(configuration["ConnectionStrings:DefaultConnection"]))
+    {
+      violations.Add("Missing ConnectionStrings:DefaultConnection");
+    }
+
+    var jwtKeyValue = configuration["Jwt:Key"];
+    if (string.IsNullOrWhiteSpace(jwtKeyValue) || jwtKeyValue == "SET_VIA_USER_SECRETS_OR_ENV_VAR")
+    {
+      violations.Add("Missing Jwt:Key");
+    }
+
+    return violations;
+  }
+
+  [SuppressMessage(
+    "Security",
+    "S2068:Credentials should not be hard-coded",
+    Justification = "These are sentinel placeholders used to detect insecure default configuration values.")]
+  private static List<string> GetSecurityConfigurationViolations(
+    IConfiguration configuration,
+    IHostEnvironment environment)
+  {
+    var violations = new List<string>();
+    var jwtKeyValue = configuration["Jwt:Key"];
+
+    if (!string.IsNullOrWhiteSpace(jwtKeyValue)
+      && jwtKeyValue != "SET_VIA_USER_SECRETS_OR_ENV_VAR"
+      && jwtKeyValue.Length < 32)
+    {
+      violations.Add("Jwt:Key must be at least 32 characters long");
+    }
+
+    var defaultConnection = configuration["ConnectionStrings:DefaultConnection"] ?? string.Empty;
+    if (!environment.IsDevelopment()
+      && ContainsAny(defaultConnection, "aarogya_dev_password", "your_password", "password=changeme"))
+    {
+      violations.Add("ConnectionStrings:DefaultConnection contains insecure default credentials");
+    }
+
+    var redisConnection = configuration["ConnectionStrings:Redis"] ?? string.Empty;
+    if (!environment.IsDevelopment()
+      && ContainsAny(redisConnection, "redis_password", "changeme", "SET_VIA_USER_SECRETS_OR_ENV_VAR"))
+    {
+      violations.Add("ConnectionStrings:Redis contains insecure default credentials");
+    }
+
+    var awsServiceUrl = configuration["Aws:ServiceUrl"];
+    if (!string.IsNullOrWhiteSpace(awsServiceUrl)
+      && (!Uri.TryCreate(awsServiceUrl, UriKind.Absolute, out var parsed)
+      || (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)))
+    {
+      violations.Add("Aws:ServiceUrl must be a valid absolute HTTP/HTTPS URL");
+    }
+
+    var corsOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+    foreach (var origin in corsOrigins)
+    {
+      if (!Uri.TryCreate(origin, UriKind.Absolute, out var originUri)
+        || (originUri.Scheme != Uri.UriSchemeHttp && originUri.Scheme != Uri.UriSchemeHttps))
+      {
+        violations.Add($"Cors:AllowedOrigins contains invalid URL: {origin}");
+      }
+    }
+
+    return violations;
+  }
+
+  private static bool ContainsAny(string value, params string[] patterns)
+  {
+    return Array.Exists(patterns, pattern => value.Contains(pattern, StringComparison.OrdinalIgnoreCase));
   }
 }

--- a/tests/Aarogya.Api.Tests/ConfigurationValidationTests.cs
+++ b/tests/Aarogya.Api.Tests/ConfigurationValidationTests.cs
@@ -1,0 +1,85 @@
+using Aarogya.Api.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public class ConfigurationValidationTests
+{
+  [Fact]
+  public void ValidateRequiredConfiguration_ShouldThrowInProduction_WhenJwtKeyMissing()
+  {
+    var configuration = BuildConfiguration(new Dictionary<string, string?>
+    {
+      ["ConnectionStrings:DefaultConnection"] = "Host=db;Username=user;Password=strong-password"
+    });
+
+    var action = () => StartupExtensions.ValidateRequiredConfiguration(configuration, new TestHostEnvironment("Production"));
+
+    action.Should().Throw<InvalidOperationException>()
+      .WithMessage("*Missing Jwt:Key*");
+  }
+
+  [Fact]
+  public void ValidateRequiredConfiguration_ShouldThrowInProduction_WhenDefaultDbPasswordIsUsed()
+  {
+    var configuration = BuildConfiguration(new Dictionary<string, string?>
+    {
+      ["ConnectionStrings:DefaultConnection"] =
+        "Host=db;Port=5432;Database=aarogya;Username=aarogya;Password=aarogya_dev_password",
+      ["Jwt:Key"] = "this-is-a-valid-jwt-key-with-more-than-thirty-two-characters"
+    });
+
+    var action = () => StartupExtensions.ValidateRequiredConfiguration(configuration, new TestHostEnvironment("Production"));
+
+    action.Should().Throw<InvalidOperationException>()
+      .WithMessage("*insecure default credentials*");
+  }
+
+  [Fact]
+  public void ValidateRequiredConfiguration_ShouldThrowInProduction_WhenAwsServiceUrlIsInvalid()
+  {
+    var configuration = BuildConfiguration(new Dictionary<string, string?>
+    {
+      ["ConnectionStrings:DefaultConnection"] = "Host=db;Username=user;Password=strong-password",
+      ["Jwt:Key"] = "this-is-a-valid-jwt-key-with-more-than-thirty-two-characters",
+      ["Aws:ServiceUrl"] = "not-a-url"
+    });
+
+    var action = () => StartupExtensions.ValidateRequiredConfiguration(configuration, new TestHostEnvironment("Production"));
+
+    action.Should().Throw<InvalidOperationException>()
+      .WithMessage("*Aws:ServiceUrl must be a valid absolute HTTP/HTTPS URL*");
+  }
+
+  [Fact]
+  public void ValidateRequiredConfiguration_ShouldNotThrowInDevelopment_WhenConfigurationIsIncomplete()
+  {
+    var configuration = BuildConfiguration(new Dictionary<string, string?>
+    {
+      ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Password=aarogya_dev_password"
+    });
+
+    var action = () => StartupExtensions.ValidateRequiredConfiguration(configuration, new TestHostEnvironment("Development"));
+
+    action.Should().NotThrow();
+  }
+
+  private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+  {
+    return new ConfigurationBuilder()
+      .AddInMemoryCollection(values)
+      .Build();
+  }
+
+  private sealed class TestHostEnvironment(string environmentName) : IHostEnvironment
+  {
+    public string EnvironmentName { get; set; } = environmentName;
+    public string ApplicationName { get; set; } = "Aarogya.Api.Tests";
+    public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+  }
+}


### PR DESCRIPTION
Closes #121\n\n## Summary\n- harden startup configuration validation with required-key and security checks\n- add URL/type validation for config-driven endpoints and origin settings\n- add repository pre-commit secret scan hook and installer script\n- extend .gitignore for sensitive local config patterns\n- add API tests for configuration validation behavior\n- document configuration security best practices in README\n\n## Validation\n- dotnet build Aarogya.sln --no-restore -nologo\n- dotnet test tests/Aarogya.Api.Tests/Aarogya.Api.Tests.csproj -nologo --no-build\n- local sonar pre-check (begin + build only)