### PR TITLE
ci: strengthen PR pipeline with cache and test reports

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Publish test results
       if: always()
-      uses: dorny/test-reporter@v1
+      uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5
       with:
         name: .NET Test Results
         path: ./.testresults/**/*.trx


### PR DESCRIPTION
## Summary
- enable NuGet cache in CI jobs using actions/setup-dotnet cache support
- keep build/test/lint gates active for pull requests
- publish test results as TRX artifacts and PR check annotations

## Validation
- dotnet test Aarogya.sln -nologo

Closes #9