### PR TITLE
chore: optimize API Dockerfile for smaller runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Build stage
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 WORKDIR /src
 
 COPY ["Aarogya.sln", "./"]
@@ -12,14 +11,20 @@ COPY ["src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj", "src/Aarogya.I
 RUN dotnet restore "src/Aarogya.Api/Aarogya.Api.csproj"
 
 COPY . .
-RUN dotnet publish "src/Aarogya.Api/Aarogya.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "src/Aarogya.Api/Aarogya.Api.csproj" \
+  -c Release \
+  -o /app/publish \
+  /p:UseAppHost=false \
+  /p:DebugType=None \
+  /p:DebugSymbols=false
 
-# Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS final
 WORKDIR /app
 
 ENV ASPNETCORE_URLS=http://+:8080
 EXPOSE 8080
 
 COPY --from=build /app/publish .
+USER $APP_UID
+
 ENTRYPOINT ["dotnet", "Aarogya.Api.dll"]


### PR DESCRIPTION
## Summary
- optimize the API Dockerfile using .NET 9 alpine SDK/runtime images
- keep multi-stage publish and reduce output symbols in release publish
- run container as non-root (`USER $APP_UID`) in runtime stage

## Validation
- `docker build -t aarogya-api:issue10 .`
- `docker image inspect aarogya-api:issue10 --format '{{.Size}}'` => `133.37 MB`
- run container with development env overrides and verify `http://localhost:18080/swagger/index.html`
- local SonarScanner begin + build

Closes #10
