### PR TITLE
feat: configure ef core with postgresql migrations

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "9.0.13",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ tests/
 
 4. **Run database migrations** (when available)
    ```bash
-   dotnet ef database update --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Api
+   dotnet tool restore
+   dotnet ef database update --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/
    ```
 
 5. **Run the application**
@@ -179,19 +180,24 @@ dotnet format
 
 ### Database Migrations
 
+Restore local tools first:
+```bash
+dotnet tool restore
+```
+
 Create migration:
 ```bash
-dotnet ef migrations add MigrationName --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Api
+dotnet ef migrations add MigrationName --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/
 ```
 
 Apply migration:
 ```bash
-dotnet ef database update --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Api
+dotnet ef database update --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/
 ```
 
 Remove last migration:
 ```bash
-dotnet ef migrations remove --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Api
+dotnet ef migrations remove --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/
 ```
 
 ## 📦 Dependencies

--- a/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
+++ b/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
@@ -18,6 +18,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>

--- a/src/Aarogya.Infrastructure/Persistence/AarogyaDbContextFactory.cs
+++ b/src/Aarogya.Infrastructure/Persistence/AarogyaDbContextFactory.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Aarogya.Infrastructure.Persistence;
+
+/// <summary>
+/// Design-time factory used by dotnet-ef for migration scaffolding.
+/// </summary>
+public sealed class AarogyaDbContextFactory : IDesignTimeDbContextFactory<AarogyaDbContext>
+{
+  public AarogyaDbContext CreateDbContext(string[] args)
+  {
+    var connectionString =
+      Environment.GetEnvironmentVariable("AAROGYA_ConnectionStrings__DefaultConnection")
+      ?? Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
+      ?? "Host=localhost;Port=5432;Database=aarogya;Username=aarogya;Password=aarogya_dev_password";
+
+    var optionsBuilder = new DbContextOptionsBuilder<AarogyaDbContext>();
+    optionsBuilder.UseNpgsql(connectionString, npgsqlOptions =>
+    {
+      npgsqlOptions.MigrationsAssembly(typeof(AarogyaDbContext).Assembly.FullName);
+      npgsqlOptions.CommandTimeout(30);
+    });
+
+    return new AarogyaDbContext(optionsBuilder.Options);
+  }
+}


### PR DESCRIPTION
## Summary
- add local dotnet tools manifest and pin dotnet-ef for consistent migration tooling
- add design-time AarogyaDbContextFactory for reliable EF Core migration scaffolding
- ensure EF Core tooling package versions are declared centrally and referenced in infrastructure project
- update README migration commands to include tool restore and repository-specific --msbuildprojectextensionspath

## Validation
- dotnet build Aarogya.sln -nologo
- dotnet ef migrations list --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --context AarogyaDbContext --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/
- dotnet ef migrations add VerifyIssue12 --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --context AarogyaDbContext --output-dir Persistence/Migrations --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/
- dotnet ef migrations remove --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --context AarogyaDbContext --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/ --force
- local SonarScanner begin + build

Closes #12
