### PR TITLE
feat: set up database health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ tests/
    - HTTPS: `https://localhost:5001`
    - HTTP: `http://localhost:5000`
    - Swagger UI: `https://localhost:5001/swagger`
+   - Health (all checks): `https://localhost:5001/health`
+   - Health (readiness): `https://localhost:5001/health/ready`
 
 ## 🧪 Dev Container
 
@@ -343,6 +345,20 @@ Then open `http://localhost:5050` with:
 - Password: `admin`
 
 If using `k9s`, switch namespace to `aarogya` to view these pods.
+
+## 🩺 Health Checks
+
+Health checks are configured via ASP.NET Core health check middleware.
+
+Endpoints:
+- `/health` (all checks)
+- `/health/ready` (checks tagged as `ready`)
+
+Database health check:
+- Name: `postgresql`
+- Includes a configurable timeout via `Database:HealthCheckTimeoutSeconds` in:
+  - `src/Aarogya.Api/appsettings.json`
+  - `src/Aarogya.Api/appsettings.Development.json`
 
 ## 🧰 Redis Cache Configuration
 

--- a/src/Aarogya.Api/Configuration/DatabaseOptions.cs
+++ b/src/Aarogya.Api/Configuration/DatabaseOptions.cs
@@ -41,4 +41,10 @@ public sealed class DatabaseOptions
   /// Should only be true in Development.
   /// </summary>
   public bool AutoMigrateOnStartup { get; set; }
+
+  /// <summary>
+  /// Timeout in seconds for database health check execution.
+  /// </summary>
+  [Range(1, 60)]
+  public int HealthCheckTimeoutSeconds { get; set; } = 5;
 }

--- a/src/Aarogya.Api/Health/HealthCheckResponseWriter.cs
+++ b/src/Aarogya.Api/Health/HealthCheckResponseWriter.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aarogya.Api.Health;
+
+internal static class HealthCheckResponseWriter
+{
+  private static readonly JsonSerializerOptions SerializerOptions = new()
+  {
+    WriteIndented = true
+  };
+
+  public static Task WriteResponse(HttpContext context, HealthReport report)
+  {
+    context.Response.ContentType = "application/json; charset=utf-8";
+
+    var payload = new
+    {
+      status = report.Status.ToString(),
+      totalDurationMs = report.TotalDuration.TotalMilliseconds,
+      checks = report.Entries.ToDictionary(
+        entry => entry.Key,
+        entry => new
+        {
+          status = entry.Value.Status.ToString(),
+          durationMs = entry.Value.Duration.TotalMilliseconds,
+          description = entry.Value.Description,
+          error = entry.Value.Exception?.Message,
+          data = entry.Value.Data.ToDictionary(
+            item => item.Key,
+            item => item.Value?.ToString())
+        })
+    };
+
+    return context.Response.WriteAsync(JsonSerializer.Serialize(payload, SerializerOptions));
+  }
+}

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -1,4 +1,5 @@
 using Aarogya.Api.Configuration;
+using Aarogya.Api.Health;
 using Aarogya.Infrastructure;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -137,11 +138,13 @@ app.MapControllers();
 // Health check endpoints
 app.MapHealthChecks("/health", new HealthCheckOptions
 {
-  Predicate = _ => true
+  Predicate = _ => true,
+  ResponseWriter = HealthCheckResponseWriter.WriteResponse
 });
 app.MapHealthChecks("/health/ready", new HealthCheckOptions
 {
-  Predicate = check => check.Tags.Contains("ready")
+  Predicate = check => check.Tags.Contains("ready"),
+  ResponseWriter = HealthCheckResponseWriter.WriteResponse
 });
 
 try

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -72,7 +72,8 @@
     "EnableSensitiveDataLogging": true,
     "MaxRetryCount": 3,
     "MaxRetryDelaySeconds": 5,
-    "AutoMigrateOnStartup": true
+    "AutoMigrateOnStartup": true,
+    "HealthCheckTimeoutSeconds": 5
   },
   "HealthChecks": {
     "EnableDetailedOutput": true

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -71,6 +71,7 @@
     "EnableSensitiveDataLogging": false,
     "MaxRetryCount": 3,
     "MaxRetryDelaySeconds": 5,
-    "AutoMigrateOnStartup": false
+    "AutoMigrateOnStartup": false,
+    "HealthCheckTimeoutSeconds": 5
   }
 }

--- a/src/Aarogya.Infrastructure/DependencyInjection.cs
+++ b/src/Aarogya.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Aarogya.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Aarogya.Infrastructure;
 
@@ -30,6 +31,7 @@ public static class DependencyInjection
     var enableSensitiveDataLogging = dbSection.GetSection("EnableSensitiveDataLogging").Get<bool?>() ?? false;
     var maxRetryCount = dbSection.GetSection("MaxRetryCount").Get<int?>() ?? 3;
     var maxRetryDelaySeconds = dbSection.GetSection("MaxRetryDelaySeconds").Get<int?>() ?? 5;
+    var healthCheckTimeoutSeconds = dbSection.GetSection("HealthCheckTimeoutSeconds").Get<int?>() ?? 5;
     var redisSection = configuration.GetSection("Redis");
     var redisConnectionString = configuration.GetConnectionString("Redis");
     var redisInstanceName = redisSection.GetSection("InstanceName").Get<string>() ?? "aarogya_";
@@ -83,7 +85,11 @@ public static class DependencyInjection
 
     // Register a health check for PostgreSQL
     var healthChecks = services.AddHealthChecks()
-      .AddDbContextCheck<AarogyaDbContext>("postgresql", tags: ["db", "ready"]);
+      .AddCheck<PostgreSqlConnectionHealthCheck>(
+        "postgresql",
+        failureStatus: HealthStatus.Unhealthy,
+        tags: ["db", "ready"],
+        timeout: TimeSpan.FromSeconds(healthCheckTimeoutSeconds));
 
     if (!string.IsNullOrWhiteSpace(redisConnectionString))
     {

--- a/src/Aarogya.Infrastructure/Persistence/PostgreSqlConnectionHealthCheck.cs
+++ b/src/Aarogya.Infrastructure/Persistence/PostgreSqlConnectionHealthCheck.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Aarogya.Infrastructure.Persistence;
+
+internal sealed class PostgreSqlConnectionHealthCheck(IServiceScopeFactory serviceScopeFactory) : IHealthCheck
+{
+  public async Task<HealthCheckResult> CheckHealthAsync(
+    HealthCheckContext context,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(context);
+
+    try
+    {
+      using var scope = serviceScopeFactory.CreateScope();
+      var dbContext = scope.ServiceProvider.GetRequiredService<AarogyaDbContext>();
+      var canConnect = await dbContext.Database.CanConnectAsync(cancellationToken);
+
+      return canConnect
+        ? HealthCheckResult.Healthy("PostgreSQL connectivity check succeeded.")
+        : HealthCheckResult.Unhealthy("PostgreSQL connectivity check failed.");
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      return HealthCheckResult.Unhealthy("PostgreSQL connectivity check timed out.");
+    }
+    catch (Exception ex)
+    {
+      return HealthCheckResult.Unhealthy("PostgreSQL connectivity check failed.", ex);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add explicit PostgreSQL connectivity health check integrated with ASP.NET Core health checks
- configure database health check timeout via Database:HealthCheckTimeoutSeconds
- return structured JSON health output on /health and /health/ready
- document health endpoints and timeout setting in README

## Validation
- dotnet format --verify-no-changes --verbosity minimal
- dotnet build Aarogya.sln -nologo
- dotnet test Aarogya.sln -nologo

Closes #15