### PR TITLE
docs: validate JSONB indexing for report data

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ Remove last migration:
 dotnet ef migrations remove --project src/Aarogya.Infrastructure --startup-project src/Aarogya.Infrastructure --msbuildprojectextensionspath artifacts/obj/Aarogya.Infrastructure/
 ```
 
+JSONB index verification:
+```bash
+psql "<connection-string>" -f docs/database/jsonb-index-verification.sql
+```
+
 ## 📦 Dependencies
 
 ### API Layer

--- a/docs/database/jsonb-index-verification.sql
+++ b/docs/database/jsonb-index-verification.sql
@@ -1,0 +1,34 @@
+-- JSONB index verification script for issue #17.
+-- Run against a database with representative data volume.
+-- Expected: planner uses GIN indexes for selective @> predicates.
+
+-- Verify JSONB GIN indexes exist
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname IN (
+    'ix_reports_results_gin',
+    'ix_reports_metadata_gin',
+    'ix_report_parameters_raw_parameter_gin',
+    'ix_access_grants_scope_gin',
+    'ix_audit_logs_details_gin'
+  )
+ORDER BY indexname;
+
+-- Common selective query pattern: report source lookup in metadata
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT count(*)
+FROM reports
+WHERE metadata @> '{"source":"lab-rare"}'::jsonb;
+
+-- Common selective query pattern: specific parameter code from report results
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT count(*)
+FROM reports
+WHERE results @> '{"parameters":[{"code":"TSH"}]}'::jsonb;
+
+-- Selective query pattern: raw parsed parameter lookup
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT count(*)
+FROM report_parameters
+WHERE raw_parameter @> '{"code":"NON_EXISTENT_CODE"}'::jsonb;


### PR DESCRIPTION
## Summary
- confirm JSONB GIN indexes are already configured in EF model and migration
- add a repeatable SQL verification script for index existence and EXPLAIN ANALYZE checks
- document how to run the JSONB verification script in README

## Validation
- dotnet format --verify-no-changes --verbosity minimal
- dotnet build Aarogya.sln -nologo
- dotnet test Aarogya.sln -nologo
- executed EXPLAIN ANALYZE against seeded PostgreSQL data:
  - reports.metadata query uses ix_reports_metadata_gin (Bitmap Index Scan)
  - reports.results query uses ix_reports_results_gin (Bitmap Index Scan)
  - report_parameters.raw_parameter selective query uses ix_report_parameters_raw_parameter_gin (Bitmap Index Scan)

Closes #17