### PR TITLE
feat(api): configure swagger/openapi docs (#31)

### DIFF
--- a/src/Aarogya.Api/Endpoints/V1EndpointMappings.cs
+++ b/src/Aarogya.Api/Endpoints/V1EndpointMappings.cs
@@ -34,7 +34,12 @@ internal static class V1EndpointMappings
       .RequireAuthorization(AarogyaPolicies.AnyRegisteredRole);
 
     users.MapGet("/me", (HttpContext context, IUsersEndpointService service)
-      => TypedResults.Ok(service.GetCurrentUser(context.User)));
+      => TypedResults.Ok(service.GetCurrentUser(context.User)))
+      .WithName("GetCurrentUserProfileV1")
+      .WithSummary("Get current user profile")
+      .WithDescription("Returns the authenticated user's profile and resolved roles.")
+      .Produces<UserProfileResponse>(StatusCodes.Status200OK)
+      .Produces(StatusCodes.Status401Unauthorized);
   }
 
   private static void MapReports(RouteGroupBuilder v1)
@@ -53,7 +58,12 @@ internal static class V1EndpointMappings
 
       var result = await service.GetForUserAsync(userSub, ct);
       return Results.Ok(result);
-    });
+    })
+      .WithName("ListReportsV1")
+      .WithSummary("List reports")
+      .WithDescription("Returns report summaries available to the authenticated user.")
+      .Produces<IReadOnlyList<ReportSummaryResponse>>(StatusCodes.Status200OK)
+      .Produces(StatusCodes.Status401Unauthorized);
 
     reports.MapPost("/", async (CreateReportRequest request, HttpContext context, IReportsEndpointService service, CancellationToken ct) =>
     {
@@ -70,7 +80,14 @@ internal static class V1EndpointMappings
 
       var result = await service.AddForUserAsync(userSub, request, ct);
       return Results.Created($"/api/v1/reports/{result.ReportId}", result);
-    });
+    })
+      .WithName("CreateReportV1")
+      .WithSummary("Create report")
+      .WithDescription("Creates a report placeholder metadata entry for the authenticated user.")
+      .Accepts<CreateReportRequest>("application/json")
+      .Produces<ReportSummaryResponse>(StatusCodes.Status201Created)
+      .Produces<ApiError>(StatusCodes.Status400BadRequest)
+      .Produces(StatusCodes.Status401Unauthorized);
   }
 
   private static void MapAccessGrants(RouteGroupBuilder v1)
@@ -89,7 +106,13 @@ internal static class V1EndpointMappings
 
       var result = await service.GetForPatientAsync(patientSub, ct);
       return Results.Ok(result);
-    });
+    })
+      .WithName("ListAccessGrantsV1")
+      .WithSummary("List access grants")
+      .WithDescription("Returns access grants created by the authenticated patient.")
+      .Produces<IReadOnlyList<AccessGrantResponse>>(StatusCodes.Status200OK)
+      .Produces(StatusCodes.Status401Unauthorized)
+      .Produces(StatusCodes.Status403Forbidden);
 
     grants.MapPost("/", async (CreateAccessGrantRequest request, HttpContext context, IAccessGrantsEndpointService service, CancellationToken ct) =>
     {
@@ -108,7 +131,15 @@ internal static class V1EndpointMappings
 
       var created = await service.CreateAsync(patientSub, request, ct);
       return Results.Created($"/api/v1/access-grants/{created.GrantId}", created);
-    });
+    })
+      .WithName("CreateAccessGrantV1")
+      .WithSummary("Create access grant")
+      .WithDescription("Creates a doctor access grant for selected reports.")
+      .Accepts<CreateAccessGrantRequest>("application/json")
+      .Produces<AccessGrantResponse>(StatusCodes.Status201Created)
+      .Produces<ApiError>(StatusCodes.Status400BadRequest)
+      .Produces(StatusCodes.Status401Unauthorized)
+      .Produces(StatusCodes.Status403Forbidden);
 
     grants.MapDelete("/{grantId:guid}", async (Guid grantId, HttpContext context, IAccessGrantsEndpointService service, CancellationToken ct) =>
     {
@@ -120,7 +151,14 @@ internal static class V1EndpointMappings
 
       var revoked = await service.RevokeAsync(patientSub, grantId, ct);
       return revoked ? Results.NoContent() : Results.NotFound();
-    });
+    })
+      .WithName("RevokeAccessGrantV1")
+      .WithSummary("Revoke access grant")
+      .WithDescription("Revokes a previously issued access grant.")
+      .Produces(StatusCodes.Status204NoContent)
+      .Produces(StatusCodes.Status401Unauthorized)
+      .Produces(StatusCodes.Status403Forbidden)
+      .Produces(StatusCodes.Status404NotFound);
   }
 
   private static void MapEmergencyContacts(RouteGroupBuilder v1)
@@ -139,7 +177,12 @@ internal static class V1EndpointMappings
 
       var result = await service.GetForUserAsync(userSub, ct);
       return Results.Ok(result);
-    });
+    })
+      .WithName("ListEmergencyContactsV1")
+      .WithSummary("List emergency contacts")
+      .WithDescription("Returns emergency contacts for the authenticated user.")
+      .Produces<IReadOnlyList<EmergencyContactResponse>>(StatusCodes.Status200OK)
+      .Produces(StatusCodes.Status401Unauthorized);
 
     contacts.MapPost("/", async (CreateEmergencyContactRequest request, HttpContext context, IEmergencyContactsEndpointService service, CancellationToken ct) =>
     {
@@ -158,7 +201,14 @@ internal static class V1EndpointMappings
 
       var created = await service.AddForUserAsync(userSub, request, ct);
       return Results.Created($"/api/v1/emergency-contacts/{created.ContactId}", created);
-    });
+    })
+      .WithName("CreateEmergencyContactV1")
+      .WithSummary("Create emergency contact")
+      .WithDescription("Adds an emergency contact for the authenticated user.")
+      .Accepts<CreateEmergencyContactRequest>("application/json")
+      .Produces<EmergencyContactResponse>(StatusCodes.Status201Created)
+      .Produces<ApiError>(StatusCodes.Status400BadRequest)
+      .Produces(StatusCodes.Status401Unauthorized);
 
     contacts.MapDelete("/{contactId:guid}", async (Guid contactId, HttpContext context, IEmergencyContactsEndpointService service, CancellationToken ct) =>
     {
@@ -170,7 +220,13 @@ internal static class V1EndpointMappings
 
       var deleted = await service.DeleteForUserAsync(userSub, contactId, ct);
       return deleted ? Results.NoContent() : Results.NotFound();
-    });
+    })
+      .WithName("DeleteEmergencyContactV1")
+      .WithSummary("Delete emergency contact")
+      .WithDescription("Deletes an emergency contact for the authenticated user.")
+      .Produces(StatusCodes.Status204NoContent)
+      .Produces(StatusCodes.Status401Unauthorized)
+      .Produces(StatusCodes.Status404NotFound);
   }
 
   private static string? GetRequiredSub(ClaimsPrincipal principal)

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -90,17 +90,20 @@ builder.Services.AddSwaggerGen(c =>
   {
     Title = "Aarogya API",
     Version = "v1",
-    Description = "Backend API for Aarogya mobile application"
+    Description = "Backend API for Aarogya mobile application (versioned under /api/v1)."
   });
+
+  c.SupportNonNullableReferenceTypes();
 
   // Add JWT Authentication to Swagger
   c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
   {
-    Description = "JWT Authorization header using the Bearer scheme. Enter 'Bearer' [space] and then your token",
+    Description = "JWT Authorization header using the Bearer scheme. Example: 'Bearer {token}'",
     Name = "Authorization",
     In = ParameterLocation.Header,
-    Type = SecuritySchemeType.ApiKey,
-    Scheme = "Bearer"
+    Type = SecuritySchemeType.Http,
+    Scheme = "bearer",
+    BearerFormat = "JWT"
   });
 
   c.AddSecurityRequirement(new OpenApiSecurityRequirement
@@ -132,14 +135,12 @@ StartupExtensions.ValidateRequiredConfiguration(app.Configuration, app.Environme
 await StartupExtensions.InitializeDatabaseAsync(app);
 
 // Configure the HTTP request pipeline
-if (app.Environment.IsDevelopment())
+app.UseSwagger();
+app.UseSwaggerUI(c =>
 {
-  app.UseSwagger();
-  app.UseSwaggerUI(c =>
-  {
-    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Aarogya API v1");
-  });
-}
+  c.RoutePrefix = "swagger";
+  c.SwaggerEndpoint("/swagger/v1/swagger.json", "Aarogya API v1");
+});
 
 app.UseAarogyaRequestLogging();
 app.UseAarogyaApiVersioning();


### PR DESCRIPTION
## **Summary**
- strengthen OpenAPI/Swagger configuration with proper JWT bearer security scheme
- expose Swagger UI at /swagger and keep v1 document endpoint wired
- enrich minimal API endpoint groups with request/response schema metadata
- align OpenAPI docs with versioned /api/v1 route strategy

## Testing
- dotnet format --verify-no-changes --verbosity minimal --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test tests/Aarogya.Api.Tests/Aarogya.Api.Tests.csproj -nologo

Closes #31