### PR TITLE
feat(api): implement rate limiting middleware (#33)

### DIFF
--- a/src/Aarogya.Api/Configuration/RateLimitingOptions.cs
+++ b/src/Aarogya.Api/Configuration/RateLimitingOptions.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Aarogya.Api.Configuration;
+
+public sealed class RateLimitingOptions
+{
+  public const string SectionName = "RateLimiting";
+
+  public bool EnableRateLimiting { get; set; } = true;
+
+  [Required]
+  public RateLimitPolicyOptions Auth { get; set; } = new();
+
+  [Required]
+  public RateLimitPolicyOptions ApiV1 { get; set; } = new();
+}
+
+public sealed class RateLimitPolicyOptions
+{
+  [Required]
+  [RegularExpression("^(fixed|sliding)$", ErrorMessage = "Strategy must be either 'fixed' or 'sliding'.")]
+  public string Strategy { get; set; } = "fixed";
+
+  [Range(1, 10_000)]
+  public int PermitLimit { get; set; } = 120;
+
+  [Range(1, 86_400)]
+  public int WindowSeconds { get; set; } = 60;
+
+  [Range(1, 64)]
+  public int SegmentsPerWindow { get; set; } = 4;
+
+  [Range(0, 1_000)]
+  public int QueueLimit { get; set; }
+
+  public bool PreferPerUserLimits { get; set; } = true;
+}

--- a/src/Aarogya.Api/Controllers/AuthController.cs
+++ b/src/Aarogya.Api/Controllers/AuthController.cs
@@ -2,13 +2,16 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Authorization;
+using Aarogya.Api.RateLimiting;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Aarogya.Api.Controllers;
 
 [ApiController]
 [Route("api/auth")]
+[EnableRateLimiting(RateLimitPolicyNames.Auth)]
 [SuppressMessage(
   "Performance",
   "CA1515:Consider making public types internal",

--- a/src/Aarogya.Api/Endpoints/V1EndpointMappings.cs
+++ b/src/Aarogya.Api/Endpoints/V1EndpointMappings.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Aarogya.Api.Authorization;
+using Aarogya.Api.RateLimiting;
 using Aarogya.Api.Validation;
 
 namespace Aarogya.Api.Endpoints;
@@ -19,6 +20,7 @@ internal static class V1EndpointMappings
   {
     var v1 = app.MapGroup("/api/v1")
       .AddEndpointFilter<FluentValidationEndpointFilter>()
+      .RequireRateLimiting(RateLimitPolicyNames.ApiV1)
       .WithOpenApi();
 
     MapUsers(v1);

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -3,6 +3,7 @@ using Aarogya.Api.Authorization;
 using Aarogya.Api.Configuration;
 using Aarogya.Api.Endpoints;
 using Aarogya.Api.Health;
+using Aarogya.Api.RateLimiting;
 using Aarogya.Api.Validation;
 using Aarogya.Infrastructure;
 using FluentValidation;
@@ -65,6 +66,11 @@ builder.Services
 builder.Services
   .AddOptionsWithValidateOnStart<ApiKeyOptions>()
   .BindConfiguration(ApiKeyOptions.SectionName)
+  .ValidateDataAnnotations();
+
+builder.Services
+  .AddOptionsWithValidateOnStart<RateLimitingOptions>()
+  .BindConfiguration(RateLimitingOptions.SectionName)
   .ValidateDataAnnotations();
 
 // Add Infrastructure services (DbContext, health checks, etc.)
@@ -141,6 +147,11 @@ builder.Services.AddAarogyaAuthorization();
 builder.Services.AddAarogyaCorsPolicy(builder.Configuration);
 builder.Services.AddV1EndpointGroupServices();
 
+var rateLimitingOptions = builder.Configuration
+  .GetSection(RateLimitingOptions.SectionName)
+  .Get<RateLimitingOptions>() ?? new RateLimitingOptions();
+builder.Services.AddAarogyaRateLimiting(rateLimitingOptions);
+
 var app = builder.Build();
 
 // Validate required configuration at startup
@@ -161,6 +172,11 @@ app.UseAarogyaApiVersioning();
 app.UseHttpsRedirection();
 app.UseCors("AarogyaPolicy");
 app.UseAuthentication();
+if (rateLimitingOptions.EnableRateLimiting)
+{
+  app.UseRateLimiter();
+  app.UseMiddleware<RateLimitHeadersMiddleware>();
+}
 app.UseAuthorization();
 app.MapControllers();
 app.MapV1EndpointGroups();

--- a/src/Aarogya.Api/RateLimiting/InMemoryRateLimitHeaderCounter.cs
+++ b/src/Aarogya.Api/RateLimiting/InMemoryRateLimitHeaderCounter.cs
@@ -1,0 +1,92 @@
+using System.Collections.Concurrent;
+
+namespace Aarogya.Api.RateLimiting;
+
+internal interface IRateLimitHeaderCounter
+{
+  public RateLimitHeaderSnapshot TrackAccepted(RateLimitDescriptor descriptor, DateTimeOffset now);
+}
+
+internal sealed class InMemoryRateLimitHeaderCounter : IRateLimitHeaderCounter
+{
+  private readonly ConcurrentDictionary<string, FixedWindowState> _fixedWindowStates = new(StringComparer.Ordinal);
+  private readonly ConcurrentDictionary<string, SlidingWindowState> _slidingWindowStates = new(StringComparer.Ordinal);
+
+  public RateLimitHeaderSnapshot TrackAccepted(RateLimitDescriptor descriptor, DateTimeOffset now)
+  {
+    return descriptor.IsSlidingWindow
+      ? TrackSlidingWindow(descriptor, now)
+      : TrackFixedWindow(descriptor, now);
+  }
+
+  private RateLimitHeaderSnapshot TrackFixedWindow(RateLimitDescriptor descriptor, DateTimeOffset now)
+  {
+    var state = _fixedWindowStates.GetOrAdd(
+      BuildStorageKey(descriptor),
+      _ => new FixedWindowState(now));
+
+    lock (state.Gate)
+    {
+      if (now - state.WindowStart >= descriptor.Window)
+      {
+        state.WindowStart = now;
+        state.Count = 0;
+      }
+
+      state.Count++;
+      var remaining = Math.Max(0, descriptor.PermitLimit - state.Count);
+      return new RateLimitHeaderSnapshot(
+        descriptor.PermitLimit,
+        remaining,
+        state.WindowStart.Add(descriptor.Window));
+    }
+  }
+
+  private RateLimitHeaderSnapshot TrackSlidingWindow(RateLimitDescriptor descriptor, DateTimeOffset now)
+  {
+    var state = _slidingWindowStates.GetOrAdd(
+      BuildStorageKey(descriptor),
+      _ => new SlidingWindowState());
+
+    lock (state.Gate)
+    {
+      var cutoff = now - descriptor.Window;
+      while (state.Hits.Count > 0 && state.Hits.Peek() <= cutoff)
+      {
+        state.Hits.Dequeue();
+      }
+
+      state.Hits.Enqueue(now);
+      var remaining = Math.Max(0, descriptor.PermitLimit - state.Hits.Count);
+      var resetAt = state.Hits.Count == 0
+        ? now.Add(descriptor.Window)
+        : state.Hits.Peek().Add(descriptor.Window);
+
+      return new RateLimitHeaderSnapshot(
+        descriptor.PermitLimit,
+        remaining,
+        resetAt);
+    }
+  }
+
+  private static string BuildStorageKey(RateLimitDescriptor descriptor)
+    => $"{descriptor.PolicyName}:{descriptor.PartitionKey}";
+
+  private sealed class FixedWindowState
+  {
+    public FixedWindowState(DateTimeOffset windowStart)
+    {
+      WindowStart = windowStart;
+    }
+
+    public object Gate { get; } = new();
+    public DateTimeOffset WindowStart { get; set; }
+    public int Count { get; set; }
+  }
+
+  private sealed class SlidingWindowState
+  {
+    public object Gate { get; } = new();
+    public Queue<DateTimeOffset> Hits { get; } = new();
+  }
+}

--- a/src/Aarogya.Api/RateLimiting/RateLimitDescriptor.cs
+++ b/src/Aarogya.Api/RateLimiting/RateLimitDescriptor.cs
@@ -1,0 +1,17 @@
+namespace Aarogya.Api.RateLimiting;
+
+internal sealed record RateLimitDescriptor(
+  string PolicyName,
+  string PartitionKey,
+  int PermitLimit,
+  TimeSpan Window,
+  bool IsSlidingWindow,
+  int SegmentsPerWindow)
+{
+  public const string HttpContextItemKey = "__aarogya_rate_limit_descriptor";
+}
+
+internal sealed record RateLimitHeaderSnapshot(
+  int Limit,
+  int Remaining,
+  DateTimeOffset ResetAt);

--- a/src/Aarogya.Api/RateLimiting/RateLimitHeadersMiddleware.cs
+++ b/src/Aarogya.Api/RateLimiting/RateLimitHeadersMiddleware.cs
@@ -1,0 +1,28 @@
+using Aarogya.Api.Authentication;
+
+namespace Aarogya.Api.RateLimiting;
+
+internal sealed class RateLimitHeadersMiddleware(
+  RequestDelegate next,
+  IRateLimitHeaderCounter counter,
+  IUtcClock clock)
+{
+  public async Task InvokeAsync(HttpContext context)
+  {
+    await next(context);
+
+    if (context.Items.TryGetValue(RateLimitDescriptor.HttpContextItemKey, out var itemValue)
+      && itemValue is RateLimitDescriptor descriptor)
+    {
+      var snapshot = counter.TrackAccepted(descriptor, clock.UtcNow);
+      ApplyHeaders(context.Response.Headers, snapshot);
+    }
+  }
+
+  public static void ApplyHeaders(IHeaderDictionary headers, RateLimitHeaderSnapshot snapshot)
+  {
+    headers["X-RateLimit-Limit"] = snapshot.Limit.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    headers["X-RateLimit-Remaining"] = snapshot.Remaining.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    headers["X-RateLimit-Reset"] = snapshot.ResetAt.ToUnixTimeSeconds().ToString(System.Globalization.CultureInfo.InvariantCulture);
+  }
+}

--- a/src/Aarogya.Api/RateLimiting/RateLimitPolicyNames.cs
+++ b/src/Aarogya.Api/RateLimiting/RateLimitPolicyNames.cs
@@ -1,0 +1,7 @@
+namespace Aarogya.Api.RateLimiting;
+
+internal static class RateLimitPolicyNames
+{
+  public const string Auth = "auth-policy";
+  public const string ApiV1 = "api-v1-policy";
+}

--- a/src/Aarogya.Api/RateLimiting/RateLimitingServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/RateLimiting/RateLimitingServiceCollectionExtensions.cs
@@ -1,0 +1,103 @@
+using System.Security.Claims;
+using System.Threading.RateLimiting;
+using Aarogya.Api.Configuration;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace Aarogya.Api.RateLimiting;
+
+internal static class RateLimitingServiceCollectionExtensions
+{
+  public static IServiceCollection AddAarogyaRateLimiting(this IServiceCollection services, RateLimitingOptions options)
+  {
+    services.AddSingleton<IRateLimitHeaderCounter, InMemoryRateLimitHeaderCounter>();
+
+    services.AddRateLimiter(rateLimiterOptions =>
+    {
+      rateLimiterOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+      rateLimiterOptions.OnRejected = async (context, token) =>
+      {
+        if (context.HttpContext.Items.TryGetValue(RateLimitDescriptor.HttpContextItemKey, out var itemValue)
+          && itemValue is RateLimitDescriptor descriptor)
+        {
+          var retryAfter = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var delay)
+            ? DateTimeOffset.UtcNow.Add(delay)
+            : DateTimeOffset.UtcNow.Add(descriptor.Window);
+
+          RateLimitHeadersMiddleware.ApplyHeaders(
+            context.HttpContext.Response.Headers,
+            new RateLimitHeaderSnapshot(descriptor.PermitLimit, 0, retryAfter));
+        }
+
+        await context.HttpContext.Response.WriteAsJsonAsync(
+          new { error = "Too many requests. Please retry later." },
+          cancellationToken: token);
+      };
+
+      AddPolicy(rateLimiterOptions, RateLimitPolicyNames.Auth, options.Auth);
+      AddPolicy(rateLimiterOptions, RateLimitPolicyNames.ApiV1, options.ApiV1);
+    });
+
+    return services;
+  }
+
+  private static void AddPolicy(RateLimiterOptions options, string policyName, RateLimitPolicyOptions policy)
+  {
+    var window = TimeSpan.FromSeconds(policy.WindowSeconds);
+    var isSliding = string.Equals(policy.Strategy, "sliding", StringComparison.OrdinalIgnoreCase);
+
+    options.AddPolicy(policyName, httpContext =>
+    {
+      var partitionKey = GetPartitionKey(httpContext, policy.PreferPerUserLimits);
+      var descriptor = new RateLimitDescriptor(
+        policyName,
+        partitionKey,
+        policy.PermitLimit,
+        window,
+        isSliding,
+        policy.SegmentsPerWindow);
+
+      httpContext.Items[RateLimitDescriptor.HttpContextItemKey] = descriptor;
+
+      if (isSliding)
+      {
+        return RateLimitPartition.GetSlidingWindowLimiter(
+          partitionKey,
+          _ => new SlidingWindowRateLimiterOptions
+          {
+            PermitLimit = policy.PermitLimit,
+            Window = window,
+            SegmentsPerWindow = policy.SegmentsPerWindow,
+            QueueLimit = policy.QueueLimit,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            AutoReplenishment = true
+          });
+      }
+
+      return RateLimitPartition.GetFixedWindowLimiter(
+        partitionKey,
+        _ => new FixedWindowRateLimiterOptions
+        {
+          PermitLimit = policy.PermitLimit,
+          Window = window,
+          QueueLimit = policy.QueueLimit,
+          QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+          AutoReplenishment = true
+        });
+    });
+  }
+
+  private static string GetPartitionKey(HttpContext context, bool preferPerUserLimits)
+  {
+    if (preferPerUserLimits)
+    {
+      var subject = context.User.FindFirstValue("sub");
+      if (!string.IsNullOrWhiteSpace(subject))
+      {
+        return $"user:{subject}";
+      }
+    }
+
+    var ip = context.Connection.RemoteIpAddress?.ToString();
+    return string.IsNullOrWhiteSpace(ip) ? "ip:unknown" : $"ip:{ip}";
+  }
+}

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -131,7 +131,23 @@
     "EnableDetailedOutput": true
   },
   "RateLimiting": {
-    "EnableRateLimiting": false
+    "EnableRateLimiting": false,
+    "Auth": {
+      "Strategy": "fixed",
+      "PermitLimit": 60,
+      "WindowSeconds": 60,
+      "QueueLimit": 0,
+      "SegmentsPerWindow": 4,
+      "PreferPerUserLimits": true
+    },
+    "ApiV1": {
+      "Strategy": "sliding",
+      "PermitLimit": 180,
+      "WindowSeconds": 60,
+      "QueueLimit": 0,
+      "SegmentsPerWindow": 6,
+      "PreferPerUserLimits": true
+    }
   },
   "AllowedHosts": "*"
 }

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -141,5 +141,24 @@
     "MaxRetryDelaySeconds": 5,
     "AutoMigrateOnStartup": false,
     "HealthCheckTimeoutSeconds": 5
+  },
+  "RateLimiting": {
+    "EnableRateLimiting": true,
+    "Auth": {
+      "Strategy": "fixed",
+      "PermitLimit": 60,
+      "WindowSeconds": 60,
+      "QueueLimit": 0,
+      "SegmentsPerWindow": 4,
+      "PreferPerUserLimits": true
+    },
+    "ApiV1": {
+      "Strategy": "sliding",
+      "PermitLimit": 180,
+      "WindowSeconds": 60,
+      "QueueLimit": 0,
+      "SegmentsPerWindow": 6,
+      "PreferPerUserLimits": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add ASP.NET Core rate limiting with configurable fixed/sliding window policies
- enforce policy on AuthController and /api/v1 endpoint group
- apply per-user partitioning with per-IP fallback
- return HTTP 429 with rate-limit headers
- add X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset headers on allowed/rejected responses
- add environment-configurable RateLimiting settings in appsettings

## Verification
- dotnet format --verify-no-changes --verbosity minimal --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln -nologo

Closes #33
