### PR TITLE
feat(storage): add checksum verification on download (#38)

### DIFF
--- a/src/Aarogya.Api/Controllers/V1/ReportsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/ReportsController.cs
@@ -26,13 +26,16 @@ public sealed class ReportsController : ControllerBase
 {
   private readonly IReportService _reportService;
   private readonly IReportFileUploadService _reportFileUploadService;
+  private readonly IReportChecksumVerificationService _reportChecksumVerificationService;
 
   public ReportsController(
     IReportService reportService,
-    IReportFileUploadService reportFileUploadService)
+    IReportFileUploadService reportFileUploadService,
+    IReportChecksumVerificationService reportChecksumVerificationService)
   {
     _reportService = reportService;
     _reportFileUploadService = reportFileUploadService;
+    _reportChecksumVerificationService = reportChecksumVerificationService;
   }
 
   [HttpGet]
@@ -142,6 +145,55 @@ public sealed class ReportsController : ControllerBase
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
         {
           ["file"] = [ex.Message]
+        }));
+    }
+  }
+
+  [HttpPost("download-url/verified")]
+  [ProducesResponseType(typeof(VerifiedReportDownloadResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<IActionResult> CreateVerifiedDownloadUrlAsync(
+    [FromBody] CreateVerifiedReportDownloadRequest request,
+    CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    try
+    {
+      var result = await _reportChecksumVerificationService.CreateVerifiedDownloadUrlAsync(userSub, request, cancellationToken);
+      return Ok(result);
+    }
+    catch (KeyNotFoundException ex)
+    {
+      return NotFound(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["report"] = [ex.Message]
+        }));
+    }
+    catch (UnauthorizedAccessException ex)
+    {
+      return BadRequest(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["authorization"] = [ex.Message]
+        }));
+    }
+    catch (InvalidOperationException ex)
+    {
+      return BadRequest(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["checksum"] = [ex.Message]
         }));
     }
   }

--- a/src/Aarogya.Api/Features/V1/Reports/IReportChecksumVerificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/IReportChecksumVerificationService.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public controller constructor injection.")]
+public interface IReportChecksumVerificationService
+{
+  public Task<VerifiedReportDownloadResponse> CreateVerifiedDownloadUrlAsync(
+    string userSub,
+    CreateVerifiedReportDownloadRequest request,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
@@ -62,3 +62,26 @@ public sealed record ReportUploadResponse(
   long SizeBytes,
   string ChecksumSha256,
   DateTimeOffset UploadedAt);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+[SuppressMessage(
+  "Major Code Smell",
+  "S6964",
+  Justification = "FluentValidation enforces ReportId non-empty for this request model.")]
+public sealed record CreateVerifiedReportDownloadRequest(
+  Guid ReportId,
+  int? ExpiryMinutes = null);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+public sealed record VerifiedReportDownloadResponse(
+  Guid ReportId,
+  string ObjectKey,
+  Uri DownloadUrl,
+  DateTimeOffset ExpiresAt,
+  bool ChecksumVerified);

--- a/src/Aarogya.Api/Features/V1/Reports/S3ReportChecksumVerificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/S3ReportChecksumVerificationService.cs
@@ -1,0 +1,119 @@
+using System.Security.Cryptography;
+using Aarogya.Api.Authentication;
+using Aarogya.Api.Configuration;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class S3ReportChecksumVerificationService(
+  IAmazonS3 s3Client,
+  IUserRepository userRepository,
+  IReportRepository reportRepository,
+  IOptions<AwsOptions> awsOptions,
+  IUtcClock clock,
+  ILogger<S3ReportChecksumVerificationService> logger)
+  : IReportChecksumVerificationService
+{
+  public async Task<VerifiedReportDownloadResponse> CreateVerifiedDownloadUrlAsync(
+    string userSub,
+    CreateVerifiedReportDownloadRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    if (request.ReportId == Guid.Empty)
+    {
+      throw new InvalidOperationException("ReportId is required.");
+    }
+
+    var requester = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken);
+    if (requester is null)
+    {
+      throw new InvalidOperationException("Authenticated user is not provisioned in the database.");
+    }
+
+    var report = await reportRepository.GetByIdAsync(request.ReportId, cancellationToken);
+    if (report is null)
+    {
+      throw new KeyNotFoundException("Report not found.");
+    }
+
+    if (!CanAccessReport(requester.Id, requester.Role, report.PatientId, report.UploadedByUserId))
+    {
+      throw new UnauthorizedAccessException("You are not authorized to access this report.");
+    }
+
+    if (string.IsNullOrWhiteSpace(report.FileStorageKey))
+    {
+      throw new InvalidOperationException("Report does not have a file storage key.");
+    }
+
+    var expectedChecksum = report.ChecksumSha256?.Trim();
+    if (string.IsNullOrWhiteSpace(expectedChecksum))
+    {
+      throw new InvalidOperationException("Report checksum is missing.");
+    }
+
+    var actualChecksum = await ComputeChecksumFromStorageAsync(report.FileStorageKey, cancellationToken);
+    var checksumVerified = string.Equals(expectedChecksum, actualChecksum, StringComparison.OrdinalIgnoreCase);
+    if (!checksumVerified)
+    {
+      logger.LogError(
+        "Checksum mismatch detected for report {ReportId}. Expected {ExpectedChecksum}, actual {ActualChecksum}.",
+        report.Id,
+        expectedChecksum,
+        actualChecksum);
+
+      throw new InvalidOperationException("Checksum verification failed. Download blocked.");
+    }
+
+    var expiresAt = clock.UtcNow.AddMinutes(GetExpiryMinutes(request.ExpiryMinutes));
+    var downloadUrl = await s3Client.GetPreSignedURLAsync(new GetPreSignedUrlRequest
+    {
+      BucketName = awsOptions.Value.S3.BucketName,
+      Key = report.FileStorageKey,
+      Verb = HttpVerb.GET,
+      Expires = expiresAt.UtcDateTime,
+      Protocol = awsOptions.Value.UseLocalStack ? Protocol.HTTP : Protocol.HTTPS
+    });
+
+    return new VerifiedReportDownloadResponse(
+      report.Id,
+      report.FileStorageKey,
+      new Uri(downloadUrl, UriKind.Absolute),
+      expiresAt,
+      checksumVerified);
+  }
+
+  private static bool CanAccessReport(Guid requesterId, UserRole role, Guid patientId, Guid uploadedByUserId)
+  {
+    if (requesterId == patientId || requesterId == uploadedByUserId)
+    {
+      return true;
+    }
+
+    return role is UserRole.Admin or UserRole.Doctor;
+  }
+
+  private int GetExpiryMinutes(int? requestedMinutes)
+  {
+    var configured = awsOptions.Value.S3.PresignedUrlExpiryMinutes;
+    return Math.Clamp(requestedMinutes ?? configured, 1, 10080);
+  }
+
+  private async Task<string> ComputeChecksumFromStorageAsync(string objectKey, CancellationToken cancellationToken)
+  {
+    using var response = await s3Client.GetObjectAsync(new GetObjectRequest
+    {
+      BucketName = awsOptions.Value.S3.BucketName,
+      Key = objectKey
+    }, cancellationToken);
+
+    await using var stream = response.ResponseStream;
+    using var sha256 = SHA256.Create();
+    var hash = await sha256.ComputeHashAsync(stream, cancellationToken);
+    return Convert.ToHexString(hash);
+  }
+}

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddSingleton<IUserProfileService, InMemoryUserProfileService>();
     services.AddSingleton<IReportService, InMemoryReportService>();
     services.AddScoped<IReportFileUploadService, S3ReportFileUploadService>();
+    services.AddScoped<IReportChecksumVerificationService, S3ReportChecksumVerificationService>();
     services.AddSingleton<IAccessGrantService, InMemoryAccessGrantService>();
     services.AddSingleton<IEmergencyContactService, InMemoryEmergencyContactService>();
 

--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -164,6 +164,15 @@ internal sealed class CreateReportDownloadUrlRequestValidator : AbstractValidato
   }
 }
 
+internal sealed class CreateVerifiedReportDownloadRequestValidator : AbstractValidator<CreateVerifiedReportDownloadRequest>
+{
+  public CreateVerifiedReportDownloadRequestValidator()
+  {
+    RuleFor(x => x.ReportId).NotEmpty();
+    RuleFor(x => x.ExpiryMinutes).InclusiveBetween(1, 10080).When(x => x.ExpiryMinutes.HasValue);
+  }
+}
+
 internal sealed class CreateAccessGrantRequestValidator : AbstractValidator<CreateAccessGrantRequest>
 {
   public CreateAccessGrantRequestValidator()

--- a/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
@@ -18,7 +18,8 @@ public sealed class ReportsControllerTests
     var controller = CreateController(
       user: new ClaimsPrincipal(new ClaimsIdentity()),
       uploadService: Mock.Of<IReportFileUploadService>(),
-      reportService: Mock.Of<IReportService>());
+      reportService: Mock.Of<IReportService>(),
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
 
     var result = await controller.UploadReportFileAsync(CreateFormFile("application/pdf", "report.pdf"), CancellationToken.None);
 
@@ -36,7 +37,8 @@ public sealed class ReportsControllerTests
     var controller = CreateController(
       user: CreateUser("seed-PATIENT-1"),
       uploadService: uploadService.Object,
-      reportService: Mock.Of<IReportService>());
+      reportService: Mock.Of<IReportService>(),
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
 
     var result = await controller.UploadReportFileAsync(CreateFormFile("text/plain", "report.txt"), CancellationToken.None);
 
@@ -64,7 +66,8 @@ public sealed class ReportsControllerTests
     var controller = CreateController(
       user: CreateUser("seed-PATIENT-1"),
       uploadService: uploadService.Object,
-      reportService: Mock.Of<IReportService>());
+      reportService: Mock.Of<IReportService>(),
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
 
     var result = await controller.UploadReportFileAsync(CreateFormFile("application/pdf", "report.pdf"), CancellationToken.None);
 
@@ -72,12 +75,79 @@ public sealed class ReportsControllerTests
     created.Value.Should().BeEquivalentTo(expected);
   }
 
+  [Fact]
+  public async Task CreateVerifiedDownloadUrlAsync_ShouldReturnUnauthorized_WhenSubjectMissingAsync()
+  {
+    var controller = CreateController(
+      user: new ClaimsPrincipal(new ClaimsIdentity()),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: Mock.Of<IReportService>(),
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
+
+    var result = await controller.CreateVerifiedDownloadUrlAsync(
+      new CreateVerifiedReportDownloadRequest(Guid.NewGuid()),
+      CancellationToken.None);
+
+    result.Should().BeOfType<UnauthorizedResult>();
+  }
+
+  [Fact]
+  public async Task CreateVerifiedDownloadUrlAsync_ShouldReturnNotFound_WhenReportIsMissingAsync()
+  {
+    var checksumService = new Mock<IReportChecksumVerificationService>();
+    checksumService
+      .Setup(x => x.CreateVerifiedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<CreateVerifiedReportDownloadRequest>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new KeyNotFoundException("Report not found."));
+
+    var controller = CreateController(
+      user: CreateUser("seed-PATIENT-1"),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: Mock.Of<IReportService>(),
+      checksumService: checksumService.Object);
+
+    var result = await controller.CreateVerifiedDownloadUrlAsync(
+      new CreateVerifiedReportDownloadRequest(Guid.NewGuid()),
+      CancellationToken.None);
+
+    result.Should().BeOfType<NotFoundObjectResult>();
+  }
+
+  [Fact]
+  public async Task CreateVerifiedDownloadUrlAsync_ShouldReturnOk_WhenChecksumMatchesAsync()
+  {
+    var response = new VerifiedReportDownloadResponse(
+      Guid.NewGuid(),
+      "reports/seed-PATIENT-1/2026/02/20/abc.pdf",
+      new Uri("https://example.com/download"),
+      DateTimeOffset.UtcNow.AddMinutes(15),
+      true);
+
+    var checksumService = new Mock<IReportChecksumVerificationService>();
+    checksumService
+      .Setup(x => x.CreateVerifiedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<CreateVerifiedReportDownloadRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(response);
+
+    var controller = CreateController(
+      user: CreateUser("seed-PATIENT-1"),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: Mock.Of<IReportService>(),
+      checksumService: checksumService.Object);
+
+    var result = await controller.CreateVerifiedDownloadUrlAsync(
+      new CreateVerifiedReportDownloadRequest(response.ReportId),
+      CancellationToken.None);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    ok.Value.Should().BeEquivalentTo(response);
+  }
+
   private static ReportsController CreateController(
     ClaimsPrincipal user,
     IReportFileUploadService uploadService,
-    IReportService reportService)
+    IReportService reportService,
+    IReportChecksumVerificationService checksumService)
   {
-    return new ReportsController(reportService, uploadService)
+    return new ReportsController(reportService, uploadService, checksumService)
     {
       ControllerContext = new ControllerContext
       {


### PR DESCRIPTION
## Summary
- add checksum verification service for report downloads backed by S3 + DB metadata
- expose `POST /api/v1/reports/download-url/verified` to verify checksum before issuing a download URL
- block download when checksum mismatches and emit an alert log entry
- add request/response contracts and validation for verified download flow
- add controller tests for verified download endpoint (unauthorized, not found, success)

## Validation
- dotnet format --verify-no-changes --verbosity minimal --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet build Aarogya.sln -v minimal
- dotnet test tests/Aarogya.Api.Tests/Aarogya.Api.Tests.csproj -v minimal

Closes #38
