### PR TITLE
feat: implement paginated report listing filters (#42)

### DIFF
--- a/src/Aarogya.Api/Controllers/V1/ReportsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/ReportsController.cs
@@ -39,9 +39,12 @@ public sealed class ReportsController : ControllerBase
   }
 
   [HttpGet]
-  [ProducesResponseType(typeof(IReadOnlyList<ReportSummaryResponse>), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ReportListResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-  public async Task<IActionResult> ListReportsAsync(CancellationToken cancellationToken)
+  public async Task<IActionResult> ListReportsAsync(
+    [FromQuery] ReportListQueryRequest request,
+    CancellationToken cancellationToken)
   {
     var userSub = User.GetSubjectOrNull();
     if (userSub is null)
@@ -49,8 +52,20 @@ public sealed class ReportsController : ControllerBase
       return Unauthorized();
     }
 
-    var result = await _reportService.GetForUserAsync(userSub, cancellationToken);
-    return Ok(result);
+    try
+    {
+      var result = await _reportService.GetForUserAsync(userSub, request, cancellationToken);
+      return Ok(result);
+    }
+    catch (InvalidOperationException ex)
+    {
+      return BadRequest(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["query"] = [ex.Message]
+        }));
+    }
   }
 
   [HttpPost]

--- a/src/Aarogya.Api/Features/V1/Reports/IReportService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/IReportService.cs
@@ -8,7 +8,10 @@ namespace Aarogya.Api.Features.V1.Reports;
   Justification = "Used by public controller constructor injection.")]
 public interface IReportService
 {
-  public Task<IReadOnlyList<ReportSummaryResponse>> GetForUserAsync(string userSub, CancellationToken cancellationToken = default);
+  public Task<ReportListResponse> GetForUserAsync(
+    string userSub,
+    ReportListQueryRequest request,
+    CancellationToken cancellationToken = default);
 
   public Task<ReportSummaryResponse> AddForUserAsync(string userSub, CreateReportRequest request, CancellationToken cancellationToken = default);
 

--- a/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
@@ -41,6 +41,28 @@ public sealed record ReportSummaryResponse(Guid ReportId, string Title, string S
 [SuppressMessage(
   "Performance",
   "CA1515:Consider making public types internal",
+  Justification = "Used by public API action signature for query binding.")]
+public sealed record ReportListQueryRequest(
+  string? ReportType = null,
+  string? Status = null,
+  DateTimeOffset? FromDate = null,
+  DateTimeOffset? ToDate = null,
+  int Page = 1,
+  int PageSize = 20);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+public sealed record ReportListResponse(
+  int Page,
+  int PageSize,
+  int TotalCount,
+  IReadOnlyList<ReportSummaryResponse> Items);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
   Justification = "Referenced by public API action signature.")]
 public sealed record CreateReportUploadUrlRequest(
   string FileName,

--- a/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
@@ -17,6 +17,7 @@ namespace Aarogya.Api.Features.V1.Reports;
 internal sealed class ReportService(
   IAmazonS3 s3Client,
   IUserRepository userRepository,
+  IAccessGrantRepository accessGrantRepository,
   IReportRepository reportRepository,
   IUnitOfWork unitOfWork,
   IOptions<AwsOptions> awsOptions,
@@ -25,33 +26,90 @@ internal sealed class ReportService(
 {
   private readonly AwsOptions _awsOptions = awsOptions.Value;
 
-  public async Task<IReadOnlyList<ReportSummaryResponse>> GetForUserAsync(
+  public async Task<ReportListResponse> GetForUserAsync(
     string userSub,
+    ReportListQueryRequest request,
     CancellationToken cancellationToken = default)
   {
+    ArgumentNullException.ThrowIfNull(request);
     var user = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken)
       ?? throw new InvalidOperationException("Authenticated user is not provisioned in the database.");
 
-    IReadOnlyList<Report> reports;
+    var reportTypeFilter = TryParseReportTypeOrNull(request.ReportType);
+    var statusFilter = TryParseStatusOrNull(request.Status);
+
+    IReadOnlyList<Report> accessibleReports;
     if (user.Role == UserRole.LabTechnician)
     {
-      // For lab users, show reports they uploaded.
-      reports = await reportRepository.ListAsync(
+      accessibleReports = await reportRepository.ListAsync(
         new ReportsByUploaderSpecification(user.Id),
         cancellationToken);
     }
+    else if (user.Role == UserRole.Doctor)
+    {
+      var now = clock.UtcNow;
+      var grants = await accessGrantRepository.ListAsync(
+        new ActiveAccessGrantsForDoctorSpecification(user.Id, now),
+        cancellationToken);
+
+      if (grants.Count == 0)
+      {
+        return new ReportListResponse(request.Page, request.PageSize, 0, []);
+      }
+
+      var patientIds = grants.Select(grant => grant.PatientId).Distinct().ToArray();
+      var allowedReportTypes = grants
+        .SelectMany(grant => grant.Scope.AllowedReportTypes)
+        .Where(value => !string.IsNullOrWhiteSpace(value))
+        .Select(value => value.Trim())
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+      var allGrantedReports = new List<Report>();
+      foreach (var patientId in patientIds)
+      {
+        var patientReports = await reportRepository.ListByPatientAsync(patientId, cancellationToken);
+        allGrantedReports.AddRange(patientReports);
+      }
+
+      accessibleReports = allGrantedReports
+        .GroupBy(report => report.Id)
+        .Select(group => group.First())
+        .Where(report =>
+          allowedReportTypes.Length == 0
+          || Array.Exists(allowedReportTypes, allowed =>
+            allowed.Equals(ToReportTypeCode(report.ReportType), StringComparison.OrdinalIgnoreCase)))
+        .ToArray();
+    }
     else
     {
-      reports = await reportRepository.ListByPatientAsync(user.Id, cancellationToken);
+      accessibleReports = await reportRepository.ListByPatientAsync(user.Id, cancellationToken);
     }
 
-    return reports
+    var filtered = accessibleReports
+      .Where(report => !reportTypeFilter.HasValue || report.ReportType == reportTypeFilter.Value)
+      .Where(report => !statusFilter.HasValue || report.Status == statusFilter.Value)
+      .Where(report => !request.FromDate.HasValue || report.UploadedAt >= request.FromDate.Value)
+      .Where(report => !request.ToDate.HasValue || report.UploadedAt <= request.ToDate.Value)
+      .OrderByDescending(report => report.UploadedAt)
+      .ThenByDescending(report => report.CreatedAt)
+      .ToArray();
+
+    var totalCount = filtered.Length;
+    var page = Math.Max(1, request.Page);
+    var pageSize = Math.Clamp(request.PageSize, 1, 100);
+    var skip = (page - 1) * pageSize;
+    var paged = filtered.Skip(skip).Take(pageSize);
+
+    var items = paged
       .Select(report => new ReportSummaryResponse(
         report.Id,
         BuildSummaryTitle(report),
         ToStatusString(report.Status),
         report.CreatedAt))
       .ToArray();
+
+    return new ReportListResponse(page, pageSize, totalCount, items);
   }
 
   public async Task<ReportSummaryResponse> AddForUserAsync(
@@ -347,6 +405,57 @@ internal sealed class ReportService(
     }
 
     throw new InvalidOperationException("Unsupported report type.");
+  }
+
+  private static ReportType? TryParseReportTypeOrNull(string? value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return null;
+    }
+
+    return ParseReportType(value);
+  }
+
+  private static ReportStatus? TryParseStatusOrNull(string? value)
+  {
+    if (string.IsNullOrWhiteSpace(value))
+    {
+      return null;
+    }
+
+    var normalized = value.Trim();
+    if (normalized.Equals("draft", StringComparison.OrdinalIgnoreCase))
+    {
+      return ReportStatus.Draft;
+    }
+
+    if (normalized.Equals("uploaded", StringComparison.OrdinalIgnoreCase))
+    {
+      return ReportStatus.Uploaded;
+    }
+
+    if (normalized.Equals("processing", StringComparison.OrdinalIgnoreCase))
+    {
+      return ReportStatus.Processing;
+    }
+
+    if (normalized.Equals("validated", StringComparison.OrdinalIgnoreCase))
+    {
+      return ReportStatus.Validated;
+    }
+
+    if (normalized.Equals("published", StringComparison.OrdinalIgnoreCase))
+    {
+      return ReportStatus.Published;
+    }
+
+    if (normalized.Equals("archived", StringComparison.OrdinalIgnoreCase))
+    {
+      return ReportStatus.Archived;
+    }
+
+    throw new InvalidOperationException("Unsupported report status.");
   }
 
   private static string ToStatusString(ReportStatus status)

--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -186,6 +186,45 @@ internal sealed class CreateReportParameterRequestValidator : AbstractValidator<
     => request.Value.HasValue || !string.IsNullOrWhiteSpace(request.ValueText);
 }
 
+internal sealed class ReportListQueryRequestValidator : AbstractValidator<ReportListQueryRequest>
+{
+  private static readonly string[] AllowedReportTypes =
+  [
+    "blood_test",
+    "urine_test",
+    "radiology",
+    "cardiology",
+    "other"
+  ];
+
+  private static readonly string[] AllowedStatuses =
+  [
+    "draft",
+    "uploaded",
+    "processing",
+    "validated",
+    "published",
+    "archived"
+  ];
+
+  public ReportListQueryRequestValidator()
+  {
+    RuleFor(x => x.ReportType)
+      .Must(value => value is null || AllowedReportTypes.Contains(value.Trim(), StringComparer.OrdinalIgnoreCase))
+      .WithMessage("ReportType filter is invalid.");
+
+    RuleFor(x => x.Status)
+      .Must(value => value is null || AllowedStatuses.Contains(value.Trim(), StringComparer.OrdinalIgnoreCase))
+      .WithMessage("Status filter is invalid.");
+
+    RuleFor(x => x.Page).GreaterThan(0);
+    RuleFor(x => x.PageSize).InclusiveBetween(1, 100);
+    RuleFor(x => x.ToDate)
+      .GreaterThanOrEqualTo(x => x.FromDate)
+      .When(x => x.FromDate.HasValue && x.ToDate.HasValue);
+  }
+}
+
 internal sealed class CreateReportUploadUrlRequestValidator : AbstractValidator<CreateReportUploadUrlRequest>
 {
   private static readonly string[] AllowedContentTypes =

--- a/src/Aarogya.Domain/Specifications/ActiveAccessGrantsForDoctorSpecification.cs
+++ b/src/Aarogya.Domain/Specifications/ActiveAccessGrantsForDoctorSpecification.cs
@@ -1,0 +1,17 @@
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+
+namespace Aarogya.Domain.Specifications;
+
+public sealed class ActiveAccessGrantsForDoctorSpecification : BaseSpecification<AccessGrant>
+{
+  public ActiveAccessGrantsForDoctorSpecification(Guid doctorId, DateTimeOffset asOf)
+    : base(grant => grant.GrantedToUserId == doctorId
+      && grant.Status == AccessGrantStatus.Active
+      && grant.StartsAt <= asOf
+      && (grant.ExpiresAt == null || grant.ExpiresAt > asOf)
+      && grant.Scope.CanReadReports)
+  {
+    ApplyAsNoTracking();
+  }
+}

--- a/tests/Aarogya.Api.Tests/ReportServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportServiceTests.cs
@@ -53,6 +53,7 @@ public sealed class ReportServiceTests
     var service = new ReportService(
       s3Client.Object,
       userRepository.Object,
+      Mock.Of<IAccessGrantRepository>(),
       reportRepository.Object,
       unitOfWork.Object,
       Options.Create(CreateAwsOptions()),
@@ -95,6 +96,7 @@ public sealed class ReportServiceTests
     var service = new ReportService(
       Mock.Of<IAmazonS3>(),
       userRepository.Object,
+      Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IReportRepository>(),
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),

--- a/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
@@ -13,6 +13,53 @@ namespace Aarogya.Api.Tests;
 public sealed class ReportsControllerTests
 {
   [Fact]
+  public async Task ListReportsAsync_ShouldReturnUnauthorized_WhenSubjectMissingAsync()
+  {
+    var controller = CreateController(
+      user: new ClaimsPrincipal(new ClaimsIdentity()),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: Mock.Of<IReportService>(),
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
+
+    var result = await controller.ListReportsAsync(new ReportListQueryRequest(), CancellationToken.None);
+
+    result.Should().BeOfType<UnauthorizedResult>();
+  }
+
+  [Fact]
+  public async Task ListReportsAsync_ShouldReturnOk_WithPagedResponseAsync()
+  {
+    var expected = new ReportListResponse(
+      Page: 1,
+      PageSize: 20,
+      TotalCount: 1,
+      Items:
+      [
+        new ReportSummaryResponse(
+          Guid.NewGuid(),
+          "blood_test - Aarogya Diagnostics",
+          "uploaded",
+          new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero))
+      ]);
+
+    var reportService = new Mock<IReportService>();
+    reportService
+      .Setup(x => x.GetForUserAsync("seed-PATIENT-1", It.IsAny<ReportListQueryRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(expected);
+
+    var controller = CreateController(
+      user: CreateUser("seed-PATIENT-1"),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: reportService.Object,
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
+
+    var result = await controller.ListReportsAsync(new ReportListQueryRequest(), CancellationToken.None);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    ok.Value.Should().BeEquivalentTo(expected);
+  }
+
+  [Fact]
   public async Task CreateReportAsync_ShouldReturnForbidden_ForDoctorRoleAsync()
   {
     var reportService = new Mock<IReportService>();


### PR DESCRIPTION
## Summary
- add paginated report listing response with total count
- add listing filters for report type, status, and uploaded date range
- enforce doctor listing by active grants (consent-aware) while preserving patient own reports
- keep default sort by latest date descending
- add query validator for listing parameters
- add controller/service tests for listing behavior

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #42