### PR TITLE
feat: implement report detail endpoint (#43)

### DIFF
--- a/src/Aarogya.Api/Controllers/V1/ReportsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/ReportsController.cs
@@ -38,6 +38,49 @@ public sealed class ReportsController : ControllerBase
     _reportChecksumVerificationService = reportChecksumVerificationService;
   }
 
+  [HttpGet("{id:guid}")]
+  [ProducesResponseType(typeof(ReportDetailResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status403Forbidden)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<IActionResult> GetReportDetailAsync(Guid id, CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    try
+    {
+      var result = await _reportService.GetDetailForUserAsync(userSub, id, cancellationToken);
+      return Ok(result);
+    }
+    catch (KeyNotFoundException ex)
+    {
+      return NotFound(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["report"] = [ex.Message]
+        }));
+    }
+    catch (UnauthorizedAccessException)
+    {
+      return Forbid();
+    }
+    catch (InvalidOperationException ex)
+    {
+      return BadRequest(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["report"] = [ex.Message]
+        }));
+    }
+  }
+
   [HttpGet]
   [ProducesResponseType(typeof(ReportListResponse), StatusCodes.Status200OK)]
   [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]

--- a/src/Aarogya.Api/Features/V1/Reports/IReportService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/IReportService.cs
@@ -13,6 +13,11 @@ public interface IReportService
     ReportListQueryRequest request,
     CancellationToken cancellationToken = default);
 
+  public Task<ReportDetailResponse> GetDetailForUserAsync(
+    string userSub,
+    Guid reportId,
+    CancellationToken cancellationToken = default);
+
   public Task<ReportSummaryResponse> AddForUserAsync(string userSub, CreateReportRequest request, CancellationToken cancellationToken = default);
 
   public Task<ReportSignedUploadUrlResponse> GetSignedUploadUrlAsync(

--- a/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
@@ -64,6 +64,38 @@ public sealed record ReportListResponse(
   "Performance",
   "CA1515:Consider making public types internal",
   Justification = "Referenced by public API action signature.")]
+public sealed record ReportDetailParameterResponse(
+  string Code,
+  string Name,
+  decimal? NumericValue,
+  string? TextValue,
+  string? Unit,
+  string? ReferenceRange,
+  bool? IsAbnormal);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+public sealed record ReportDetailResponse(
+  Guid ReportId,
+  string ReportNumber,
+  string ReportType,
+  string Status,
+  DateTimeOffset UploadedAt,
+  DateTimeOffset CreatedAt,
+  string? LabName,
+  string? LabCode,
+  DateTimeOffset? CollectedAt,
+  DateTimeOffset? ReportedAt,
+  string? Notes,
+  IReadOnlyList<ReportDetailParameterResponse> Parameters,
+  ReportSignedDownloadUrlResponse Download);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
 public sealed record CreateReportUploadUrlRequest(
   string FileName,
   string ContentType,

--- a/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
@@ -19,6 +19,7 @@ internal sealed class ReportService(
   IUserRepository userRepository,
   IAccessGrantRepository accessGrantRepository,
   IReportRepository reportRepository,
+  IAuditLogRepository auditLogRepository,
   IUnitOfWork unitOfWork,
   IOptions<AwsOptions> awsOptions,
   IUtcClock clock)
@@ -112,6 +113,64 @@ internal sealed class ReportService(
     return new ReportListResponse(page, pageSize, totalCount, items);
   }
 
+  public async Task<ReportDetailResponse> GetDetailForUserAsync(
+    string userSub,
+    Guid reportId,
+    CancellationToken cancellationToken = default)
+  {
+    var user = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken)
+      ?? throw new InvalidOperationException("Authenticated user is not provisioned in the database.");
+
+    var report = await reportRepository.FirstOrDefaultAsync(
+      new ReportByIdSpecification(reportId),
+      cancellationToken)
+      ?? throw new KeyNotFoundException("Report not found.");
+
+    var canAccess = await CanAccessReportAsync(user, report, cancellationToken);
+    if (!canAccess)
+    {
+      throw new UnauthorizedAccessException("You do not have access to this report.");
+    }
+
+    if (string.IsNullOrWhiteSpace(report.FileStorageKey))
+    {
+      throw new InvalidOperationException("Report file reference is missing.");
+    }
+
+    var download = await CreateSignedDownloadUrlAsync(report.FileStorageKey, null, cancellationToken);
+    await WriteReportAccessAuditLogAsync(user, report, cancellationToken);
+
+    report.Metadata.Tags.TryGetValue("lab-name", out var labName);
+    report.Metadata.Tags.TryGetValue("lab-code", out var labCode);
+
+    var parameters = report.Parameters
+      .OrderBy(parameter => parameter.ParameterName, StringComparer.OrdinalIgnoreCase)
+      .Select(parameter => new ReportDetailParameterResponse(
+        parameter.ParameterCode,
+        parameter.ParameterName,
+        parameter.MeasuredValueNumeric,
+        parameter.MeasuredValueText,
+        parameter.Unit,
+        parameter.ReferenceRangeText,
+        parameter.IsAbnormal))
+      .ToArray();
+
+    return new ReportDetailResponse(
+      report.Id,
+      report.ReportNumber,
+      ToReportTypeCode(report.ReportType),
+      ToStatusString(report.Status),
+      report.UploadedAt,
+      report.CreatedAt,
+      labName,
+      labCode,
+      report.CollectedAt,
+      report.ReportedAt,
+      report.Results.Notes,
+      parameters,
+      download);
+  }
+
   public async Task<ReportSummaryResponse> AddForUserAsync(
     string userSub,
     CreateReportRequest request,
@@ -197,25 +256,7 @@ internal sealed class ReportService(
       throw new InvalidOperationException("Object key does not belong to the authenticated user.");
     }
 
-    var now = clock.UtcNow;
-    var expiresAt = now.AddMinutes(GetExpiryMinutes(request.ExpiryMinutes));
-
-    if (TryGetCloudFrontSignedUrl(request.ObjectKey, expiresAt, out var cloudFrontUrl))
-    {
-      return new ReportSignedDownloadUrlResponse(request.ObjectKey, new Uri(cloudFrontUrl, UriKind.Absolute), expiresAt, "cloudfront");
-    }
-
-    var presignRequest = new GetPreSignedUrlRequest
-    {
-      BucketName = _awsOptions.S3.BucketName,
-      Key = request.ObjectKey,
-      Verb = HttpVerb.GET,
-      Expires = expiresAt.UtcDateTime,
-      Protocol = ResolveProtocol()
-    };
-
-    var s3Url = await s3Client.GetPreSignedURLAsync(presignRequest);
-    return new ReportSignedDownloadUrlResponse(request.ObjectKey, new Uri(s3Url, UriKind.Absolute), expiresAt, "s3");
+    return await CreateSignedDownloadUrlAsync(request.ObjectKey, request.ExpiryMinutes, cancellationToken);
   }
 
   private static string BuildSummaryTitle(Report report)
@@ -226,6 +267,112 @@ internal sealed class ReportService(
     }
 
     return $"{report.ReportType} - {report.ReportNumber}";
+  }
+
+  private async Task<bool> CanAccessReportAsync(
+    User user,
+    Report report,
+    CancellationToken cancellationToken)
+  {
+    if (user.Role == UserRole.Patient)
+    {
+      return report.PatientId == user.Id;
+    }
+
+    if (user.Role == UserRole.LabTechnician)
+    {
+      return report.UploadedByUserId == user.Id;
+    }
+
+    if (user.Role != UserRole.Doctor)
+    {
+      return false;
+    }
+
+    var now = clock.UtcNow;
+    var grants = await accessGrantRepository.ListAsync(
+      new ActiveAccessGrantsForDoctorSpecification(user.Id, now),
+      cancellationToken);
+
+    var patientGrants = grants
+      .Where(grant => grant.PatientId == report.PatientId)
+      .Where(grant => grant.Scope.CanReadReports && grant.Scope.CanDownloadReports)
+      .ToArray();
+
+    if (patientGrants.Length == 0)
+    {
+      return false;
+    }
+
+    var reportTypeCode = ToReportTypeCode(report.ReportType);
+    return Array.Exists(patientGrants, grant =>
+    {
+      var allowedTypes = grant.Scope.AllowedReportTypes
+        .Where(type => !string.IsNullOrWhiteSpace(type))
+        .Select(type => type.Trim())
+        .ToArray();
+
+      return allowedTypes.Length == 0
+        || allowedTypes.Contains(reportTypeCode, StringComparer.OrdinalIgnoreCase);
+    });
+  }
+
+  private async Task<ReportSignedDownloadUrlResponse> CreateSignedDownloadUrlAsync(
+    string objectKey,
+    int? requestedExpiryMinutes,
+    CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    var now = clock.UtcNow;
+    var expiresAt = now.AddMinutes(GetExpiryMinutes(requestedExpiryMinutes));
+
+    if (TryGetCloudFrontSignedUrl(objectKey, expiresAt, out var cloudFrontUrl))
+    {
+      return new ReportSignedDownloadUrlResponse(objectKey, new Uri(cloudFrontUrl, UriKind.Absolute), expiresAt, "cloudfront");
+    }
+
+    var presignRequest = new GetPreSignedUrlRequest
+    {
+      BucketName = _awsOptions.S3.BucketName,
+      Key = objectKey,
+      Verb = HttpVerb.GET,
+      Expires = expiresAt.UtcDateTime,
+      Protocol = ResolveProtocol()
+    };
+
+    var s3Url = await s3Client.GetPreSignedURLAsync(presignRequest);
+    return new ReportSignedDownloadUrlResponse(objectKey, new Uri(s3Url, UriKind.Absolute), expiresAt, "s3");
+  }
+
+  private async Task WriteReportAccessAuditLogAsync(
+    User actor,
+    Report report,
+    CancellationToken cancellationToken)
+  {
+    var auditLog = new AuditLog
+    {
+      Id = Guid.NewGuid(),
+      OccurredAt = clock.UtcNow,
+      ActorUserId = actor.Id,
+      ActorRole = actor.Role,
+      Action = "report.viewed",
+      EntityType = "report",
+      EntityId = report.Id,
+      ResultStatus = 200,
+      Details = new AuditLogDetails
+      {
+        Summary = "Report detail accessed.",
+        Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["reportId"] = report.Id.ToString("D", CultureInfo.InvariantCulture),
+          ["reportNumber"] = report.ReportNumber,
+          ["reportType"] = ToReportTypeCode(report.ReportType)
+        }
+      }
+    };
+
+    await auditLogRepository.AddAsync(auditLog, cancellationToken);
+    await unitOfWork.SaveChangesAsync(cancellationToken);
   }
 
   private async Task<User> ResolvePatientAsync(

--- a/src/Aarogya.Domain/Specifications/ReportByIdSpecification.cs
+++ b/src/Aarogya.Domain/Specifications/ReportByIdSpecification.cs
@@ -1,0 +1,13 @@
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Domain.Specifications;
+
+public sealed class ReportByIdSpecification : BaseSpecification<Report>
+{
+  public ReportByIdSpecification(Guid reportId)
+    : base(report => report.Id == reportId)
+  {
+    AddInclude(report => report.Parameters);
+    ApplyAsNoTracking();
+  }
+}

--- a/tests/Aarogya.Api.Tests/ReportServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportServiceTests.cs
@@ -4,6 +4,8 @@ using Aarogya.Api.Features.V1.Reports;
 using Aarogya.Domain.Entities;
 using Aarogya.Domain.Enums;
 using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+using Aarogya.Domain.ValueObjects;
 using Amazon.S3;
 using Amazon.S3.Model;
 using FluentAssertions;
@@ -55,6 +57,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       Mock.Of<IAccessGrantRepository>(),
       reportRepository.Object,
+      Mock.Of<IAuditLogRepository>(),
       unitOfWork.Object,
       Options.Create(CreateAwsOptions()),
       new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)));
@@ -98,6 +101,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IReportRepository>(),
+      Mock.Of<IAuditLogRepository>(),
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
@@ -108,6 +112,151 @@ public sealed class ReportServiceTests
 
     await action.Should().ThrowAsync<InvalidOperationException>()
       .WithMessage("*PatientSub is required*");
+  }
+
+  [Fact]
+  public async Task GetDetailForUserAsync_ShouldReturnDetailAndWriteAuditLog_WhenPatientOwnsReportAsync()
+  {
+    var patient = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = "seed-PATIENT-1",
+      Role = UserRole.Patient,
+      FirstName = "Seed",
+      LastName = "Patient",
+      Email = "seed.patient@aarogya.dev"
+    };
+
+    var report = new Report
+    {
+      Id = Guid.NewGuid(),
+      ReportNumber = "RPT-ABC123DEFG",
+      PatientId = patient.Id,
+      UploadedByUserId = patient.Id,
+      ReportType = ReportType.BloodTest,
+      Status = ReportStatus.Uploaded,
+      UploadedAt = new DateTimeOffset(2026, 2, 20, 8, 0, 0, TimeSpan.Zero),
+      CreatedAt = new DateTimeOffset(2026, 2, 20, 8, 0, 0, TimeSpan.Zero),
+      FileStorageKey = "reports/seed-PATIENT-1/2026/02/report.pdf",
+      Metadata = new ReportMetadata
+      {
+        Tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["lab-name"] = "Aarogya Diagnostics",
+          ["lab-code"] = "AAR-001"
+        }
+      },
+      Results = new ReportResults
+      {
+        Notes = "Fasting sample"
+      },
+      Parameters =
+      [
+        new ReportParameter
+        {
+          ParameterCode = "HGB",
+          ParameterName = "Hemoglobin",
+          MeasuredValueNumeric = 13.4m,
+          Unit = "g/dL",
+          ReferenceRangeText = "12-16",
+          IsAbnormal = false
+        }
+      ]
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(patient);
+
+    var reportRepository = new Mock<IReportRepository>();
+    reportRepository
+      .Setup(x => x.FirstOrDefaultAsync(It.IsAny<ISpecification<Report>>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(report);
+
+    var s3Client = new Mock<IAmazonS3>();
+    s3Client
+      .Setup(x => x.GetPreSignedURLAsync(It.IsAny<GetPreSignedUrlRequest>()))
+      .ReturnsAsync("https://example.com/signed-download");
+
+    var auditLogRepository = new Mock<IAuditLogRepository>();
+    var unitOfWork = new Mock<IUnitOfWork>();
+
+    var service = new ReportService(
+      s3Client.Object,
+      userRepository.Object,
+      Mock.Of<IAccessGrantRepository>(),
+      reportRepository.Object,
+      auditLogRepository.Object,
+      unitOfWork.Object,
+      Options.Create(CreateAwsOptions()),
+      new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)));
+
+    var response = await service.GetDetailForUserAsync("seed-PATIENT-1", report.Id, CancellationToken.None);
+
+    response.ReportId.Should().Be(report.Id);
+    response.Download.Provider.Should().Be("s3");
+    response.Download.DownloadUrl.Should().Be(new Uri("https://example.com/signed-download"));
+    response.Parameters.Should().HaveCount(1);
+
+    auditLogRepository.Verify(x => x.AddAsync(It.IsAny<AuditLog>(), It.IsAny<CancellationToken>()), Times.Once);
+    unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task GetDetailForUserAsync_ShouldThrowUnauthorized_WhenDoctorHasNoActiveGrantAsync()
+  {
+    var doctor = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = "seed-DOCTOR-1",
+      Role = UserRole.Doctor,
+      FirstName = "Seed",
+      LastName = "Doctor",
+      Email = "seed.doctor@aarogya.dev"
+    };
+
+    var report = new Report
+    {
+      Id = Guid.NewGuid(),
+      ReportNumber = "RPT-XYZ9876543",
+      PatientId = Guid.NewGuid(),
+      UploadedByUserId = Guid.NewGuid(),
+      ReportType = ReportType.BloodTest,
+      Status = ReportStatus.Uploaded,
+      UploadedAt = DateTimeOffset.UtcNow,
+      CreatedAt = DateTimeOffset.UtcNow,
+      FileStorageKey = "reports/seed-PATIENT-1/2026/02/report.pdf"
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-DOCTOR-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(doctor);
+
+    var reportRepository = new Mock<IReportRepository>();
+    reportRepository
+      .Setup(x => x.FirstOrDefaultAsync(It.IsAny<ISpecification<Report>>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(report);
+
+    var accessGrantRepository = new Mock<IAccessGrantRepository>();
+    accessGrantRepository
+      .Setup(x => x.ListAsync(It.IsAny<ISpecification<AccessGrant>>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync([]);
+
+    var service = new ReportService(
+      Mock.Of<IAmazonS3>(),
+      userRepository.Object,
+      accessGrantRepository.Object,
+      reportRepository.Object,
+      Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IUnitOfWork>(),
+      Options.Create(CreateAwsOptions()),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var action = async () => await service.GetDetailForUserAsync("seed-DOCTOR-1", report.Id, CancellationToken.None);
+
+    await action.Should().ThrowAsync<UnauthorizedAccessException>();
   }
 
   private static CreateReportRequest CreateRequest()

--- a/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
@@ -27,6 +27,61 @@ public sealed class ReportsControllerTests
   }
 
   [Fact]
+  public async Task GetReportDetailAsync_ShouldReturnUnauthorized_WhenSubjectMissingAsync()
+  {
+    var controller = CreateController(
+      user: new ClaimsPrincipal(new ClaimsIdentity()),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: Mock.Of<IReportService>(),
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
+
+    var result = await controller.GetReportDetailAsync(Guid.NewGuid(), CancellationToken.None);
+
+    result.Should().BeOfType<UnauthorizedResult>();
+  }
+
+  [Fact]
+  public async Task GetReportDetailAsync_ShouldReturnOk_WhenServiceReturnsReportAsync()
+  {
+    var response = new ReportDetailResponse(
+      Guid.NewGuid(),
+      "RPT-ABC123DEFG",
+      "blood_test",
+      "uploaded",
+      new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero),
+      new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero),
+      "Aarogya Diagnostics",
+      "AAR-001",
+      new DateTimeOffset(2026, 2, 19, 0, 0, 0, TimeSpan.Zero),
+      new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero),
+      "Fasting sample",
+      [
+        new ReportDetailParameterResponse("HGB", "Hemoglobin", 13.4m, null, "g/dL", "12-16", false)
+      ],
+      new ReportSignedDownloadUrlResponse(
+        "reports/seed-PATIENT-1/2026/02/report.pdf",
+        new Uri("https://example.com/signed-download"),
+        new DateTimeOffset(2026, 2, 20, 0, 15, 0, TimeSpan.Zero),
+        "s3"));
+
+    var reportService = new Mock<IReportService>();
+    reportService
+      .Setup(x => x.GetDetailForUserAsync("seed-PATIENT-1", response.ReportId, It.IsAny<CancellationToken>()))
+      .ReturnsAsync(response);
+
+    var controller = CreateController(
+      user: CreateUser("seed-PATIENT-1"),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: reportService.Object,
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
+
+    var result = await controller.GetReportDetailAsync(response.ReportId, CancellationToken.None);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    ok.Value.Should().BeEquivalentTo(response);
+  }
+
+  [Fact]
   public async Task ListReportsAsync_ShouldReturnOk_WithPagedResponseAsync()
   {
     var expected = new ReportListResponse(


### PR DESCRIPTION
## Summary
- add GET /api/v1/reports/{id} for full report detail retrieval
- enforce role-based access checks for patient/doctor/lab-technician
- include signed download URL in the detail response and record audit log entry on access
- add unit tests for controller and service detail flow

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #43