### PR TITLE
feat: implement lab technician upload flow (#44)

### DIFF
--- a/src/Aarogya.Api/Features/V1/Reports/IPatientNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/IPatientNotificationService.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public service constructor injection.")]
+public interface IPatientNotificationService
+{
+  public Task NotifyReportUploadedAsync(
+    User patient,
+    Report report,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Reports/LoggingPatientNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/LoggingPatientNotificationService.cs
@@ -1,0 +1,20 @@
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class LoggingPatientNotificationService(ILogger<LoggingPatientNotificationService> logger)
+  : IPatientNotificationService
+{
+  public Task NotifyReportUploadedAsync(
+    User patient,
+    Report report,
+    CancellationToken cancellationToken = default)
+  {
+    logger.LogInformation(
+      "Patient notification queued for report upload. patientId={PatientId}, reportId={ReportId}, reportNumber={ReportNumber}",
+      patient.Id,
+      report.Id,
+      report.ReportNumber);
+    return Task.CompletedTask;
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
@@ -16,6 +16,8 @@ public sealed record CreateReportRequest(
   string? Notes,
   string? PatientSub,
   IReadOnlyList<CreateReportParameterRequest> Parameters,
+  string? PatientPhone = null,
+  string? PatientAadhaar = null,
   string? SourceSystem = null);
 
 [SuppressMessage(

--- a/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
@@ -20,6 +20,7 @@ internal sealed class ReportService(
   IAccessGrantRepository accessGrantRepository,
   IReportRepository reportRepository,
   IAuditLogRepository auditLogRepository,
+  IPatientNotificationService patientNotificationService,
   IUnitOfWork unitOfWork,
   IOptions<AwsOptions> awsOptions,
   IUtcClock clock)
@@ -178,16 +179,21 @@ internal sealed class ReportService(
   {
     ArgumentNullException.ThrowIfNull(request);
 
-    var uploader = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken)
-      ?? throw new InvalidOperationException("Authenticated user is not provisioned in the database.");
+    var uploader = await ResolveUploaderAsync(userSub, cancellationToken);
 
-    var patient = await ResolvePatientAsync(uploader, request.PatientSub, cancellationToken);
+    var patient = await ResolvePatientAsync(
+      uploader,
+      request.PatientSub,
+      request.PatientPhone,
+      request.PatientAadhaar,
+      cancellationToken);
 
     EnsureObjectKeyBelongsToUploader(userSub, request.ObjectKey);
     var objectMetadata = await GetObjectMetadataAsync(request.ObjectKey, cancellationToken);
 
     var now = clock.UtcNow;
     var reportType = ParseReportType(request.ReportType);
+    var sourceSystem = ResolveSourceSystem(uploader.Role, request.SourceSystem);
     var report = new Report
     {
       Id = Guid.NewGuid(),
@@ -196,14 +202,14 @@ internal sealed class ReportService(
       UploadedByUserId = uploader.Id,
       ReportType = reportType,
       Status = ReportStatus.Uploaded,
-      SourceSystem = string.IsNullOrWhiteSpace(request.SourceSystem) ? "api-upload" : request.SourceSystem.Trim(),
+      SourceSystem = sourceSystem,
       CollectedAt = request.CollectedAt,
       ReportedAt = request.ReportedAt,
       UploadedAt = now,
       FileStorageKey = request.ObjectKey.Trim(),
       ChecksumSha256 = ResolveChecksum(objectMetadata),
       Results = BuildResults(request),
-      Metadata = BuildMetadata(request, objectMetadata, reportType),
+      Metadata = BuildMetadata(request, objectMetadata, reportType, sourceSystem),
       Parameters = BuildParameters(request.Parameters, now),
       CreatedAt = now,
       UpdatedAt = now
@@ -211,6 +217,11 @@ internal sealed class ReportService(
 
     await reportRepository.AddAsync(report, cancellationToken);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+
+    if (uploader.Role == UserRole.LabTechnician)
+    {
+      await patientNotificationService.NotifyReportUploadedAsync(patient, report, cancellationToken);
+    }
 
     return new ReportSummaryResponse(
       report.Id,
@@ -378,34 +389,156 @@ internal sealed class ReportService(
   private async Task<User> ResolvePatientAsync(
     User uploader,
     string? requestedPatientSub,
+    string? requestedPatientPhone,
+    string? requestedPatientAadhaar,
     CancellationToken cancellationToken)
   {
-    if (string.IsNullOrWhiteSpace(requestedPatientSub))
+    if (uploader.Role != UserRole.LabTechnician)
     {
-      if (uploader.Role == UserRole.LabTechnician)
+      if (string.IsNullOrWhiteSpace(requestedPatientSub))
       {
-        throw new InvalidOperationException("PatientSub is required when a lab technician uploads a report.");
+        return uploader;
+      }
+
+      var normalizedPatientSub = requestedPatientSub.Trim();
+      if (!string.Equals(normalizedPatientSub, uploader.ExternalAuthId, StringComparison.Ordinal))
+      {
+        throw new InvalidOperationException("Only lab technicians can upload reports for another patient.");
       }
 
       return uploader;
     }
 
-    var normalizedPatientSub = requestedPatientSub.Trim();
-    if (uploader.Role != UserRole.LabTechnician
-      && !string.Equals(normalizedPatientSub, uploader.ExternalAuthId, StringComparison.Ordinal))
+    if (!string.IsNullOrWhiteSpace(requestedPatientSub))
     {
-      throw new InvalidOperationException("Only lab technicians can upload reports for another patient.");
+      var patientBySub = await userRepository.GetByExternalAuthIdAsync(requestedPatientSub.Trim(), cancellationToken)
+        ?? throw new InvalidOperationException("PatientSub does not match a provisioned user.");
+
+      return EnsurePatientRole(patientBySub, "PatientSub must belong to a patient user.");
     }
 
-    var patient = await userRepository.GetByExternalAuthIdAsync(normalizedPatientSub, cancellationToken)
-      ?? throw new InvalidOperationException("PatientSub does not match a provisioned user.");
-
-    if (patient.Role != UserRole.Patient)
+    if (!string.IsNullOrWhiteSpace(requestedPatientPhone))
     {
-      throw new InvalidOperationException("PatientSub must belong to a patient user.");
+      var patientByPhone = await ResolvePatientByPhoneAsync(requestedPatientPhone, cancellationToken)
+        ?? throw new InvalidOperationException("PatientPhone does not match a provisioned patient user.");
+
+      return patientByPhone;
     }
 
-    return patient;
+    if (!string.IsNullOrWhiteSpace(requestedPatientAadhaar))
+    {
+      var patientByAadhaar = await ResolvePatientByAadhaarAsync(requestedPatientAadhaar, cancellationToken)
+        ?? throw new InvalidOperationException("PatientAadhaar does not match a provisioned patient user.");
+
+      return patientByAadhaar;
+    }
+
+    throw new InvalidOperationException("PatientSub, PatientPhone, or PatientAadhaar is required for lab technician uploads.");
+  }
+
+  private async Task<User> ResolveUploaderAsync(string userSub, CancellationToken cancellationToken)
+  {
+    var user = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken);
+    if (user is not null)
+    {
+      return user;
+    }
+
+    if (!userSub.StartsWith("lab:", StringComparison.OrdinalIgnoreCase))
+    {
+      throw new InvalidOperationException("Authenticated user is not provisioned in the database.");
+    }
+
+    return await userRepository.GetFirstByRoleAsync(UserRole.LabTechnician, cancellationToken)
+      ?? throw new InvalidOperationException("No lab technician user is provisioned for API key uploads.");
+  }
+
+  private async Task<User?> ResolvePatientByPhoneAsync(string phoneInput, CancellationToken cancellationToken)
+  {
+    foreach (var candidate in ExpandPhoneCandidates(phoneInput))
+    {
+      var user = await userRepository.GetByPhoneAsync(candidate, cancellationToken);
+      if (user is not null && user.Role == UserRole.Patient)
+      {
+        return user;
+      }
+    }
+
+    return null;
+  }
+
+  private async Task<User?> ResolvePatientByAadhaarAsync(string aadhaarInput, CancellationToken cancellationToken)
+  {
+    var digitsOnly = new string(aadhaarInput.Where(char.IsDigit).ToArray());
+    if (digitsOnly.Length != 12)
+    {
+      throw new InvalidOperationException("PatientAadhaar must contain exactly 12 digits.");
+    }
+
+    var aadhaarSha256 = SHA256.HashData(Encoding.UTF8.GetBytes(digitsOnly));
+    var user = await userRepository.GetByAadhaarSha256Async(aadhaarSha256, cancellationToken);
+    if (user is null)
+    {
+      return null;
+    }
+
+    return EnsurePatientRole(user, "PatientAadhaar must belong to a patient user.");
+  }
+
+  private static IEnumerable<string> ExpandPhoneCandidates(string phoneInput)
+  {
+    if (InMemoryPhoneOtpService.TryNormalizeIndianPhone(phoneInput, out var normalizedIndian))
+    {
+      yield return normalizedIndian;
+      yield return normalizedIndian[3..];
+      yield break;
+    }
+
+    var digitsOnly = new string(phoneInput.Where(char.IsDigit).ToArray());
+    if (digitsOnly.Length == 10)
+    {
+      yield return digitsOnly;
+      yield return $"+91{digitsOnly}";
+      yield break;
+    }
+
+    if (digitsOnly.Length == 12 && digitsOnly.StartsWith("91", StringComparison.Ordinal))
+    {
+      yield return digitsOnly;
+      yield return $"+{digitsOnly}";
+      yield return digitsOnly[2..];
+      yield break;
+    }
+
+    if (!string.IsNullOrWhiteSpace(phoneInput))
+    {
+      yield return phoneInput.Trim();
+    }
+  }
+
+  private static User EnsurePatientRole(User user, string message)
+  {
+    if (user.Role != UserRole.Patient)
+    {
+      throw new InvalidOperationException(message);
+    }
+
+    return user;
+  }
+
+  private static string ResolveSourceSystem(UserRole uploaderRole, string? requestedSourceSystem)
+  {
+    if (uploaderRole == UserRole.LabTechnician)
+    {
+      return "lab-upload";
+    }
+
+    if (!string.IsNullOrWhiteSpace(requestedSourceSystem))
+    {
+      return requestedSourceSystem.Trim();
+    }
+
+    return "api-upload";
   }
 
   private static void EnsureObjectKeyBelongsToUploader(string userSub, string objectKey)
@@ -472,7 +605,8 @@ internal sealed class ReportService(
   private static ReportMetadata BuildMetadata(
     CreateReportRequest request,
     GetObjectMetadataResponse objectMetadata,
-    ReportType reportType)
+    ReportType reportType,
+    string sourceSystem)
   {
     var tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
@@ -492,9 +626,14 @@ internal sealed class ReportService(
       tags["lab-code"] = request.LabCode.Trim();
     }
 
+    if (sourceSystem.Equals("lab-upload", StringComparison.OrdinalIgnoreCase))
+    {
+      tags["upload-origin"] = "lab";
+    }
+
     return new ReportMetadata
     {
-      SourceSystem = string.IsNullOrWhiteSpace(request.SourceSystem) ? "api-upload" : request.SourceSystem.Trim(),
+      SourceSystem = sourceSystem,
       Tags = tags
     };
   }

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddScoped<IReportService, ReportService>();
     services.AddScoped<IReportFileUploadService, S3ReportFileUploadService>();
     services.AddScoped<IReportChecksumVerificationService, S3ReportChecksumVerificationService>();
+    services.AddScoped<IPatientNotificationService, LoggingPatientNotificationService>();
     services.AddHostedService<S3UploadNotificationConfiguratorHostedService>();
     services.AddHostedService<S3UploadEventConsumerHostedService>();
     services.AddSingleton<IAccessGrantService, InMemoryAccessGrantService>();

--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -152,6 +152,11 @@ internal sealed class CreateReportRequestValidator : AbstractValidator<CreateRep
     RuleFor(x => x.LabCode).MaximumLength(100).When(x => x.LabCode is not null);
     RuleFor(x => x.Notes).MaximumLength(2000).When(x => x.Notes is not null);
     RuleFor(x => x.PatientSub).NotEmpty().MaximumLength(200).When(x => x.PatientSub is not null);
+    RuleFor(x => x.PatientPhone).NotEmpty().MaximumLength(32).When(x => x.PatientPhone is not null);
+    RuleFor(x => x.PatientAadhaar)
+      .NotEmpty()
+      .Matches("^[0-9\\s-]{12,20}$")
+      .When(x => x.PatientAadhaar is not null);
 
     RuleFor(x => x.CollectedAt)
       .LessThanOrEqualTo(DateTimeOffset.UtcNow)

--- a/src/Aarogya.Domain/Repositories/IUserRepository.cs
+++ b/src/Aarogya.Domain/Repositories/IUserRepository.cs
@@ -1,8 +1,15 @@
 using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
 
 namespace Aarogya.Domain.Repositories;
 
 public interface IUserRepository : IRepository<User>
 {
   public Task<User?> GetByExternalAuthIdAsync(string externalAuthId, CancellationToken cancellationToken = default);
+
+  public Task<User?> GetByPhoneAsync(string phone, CancellationToken cancellationToken = default);
+
+  public Task<User?> GetByAadhaarSha256Async(byte[] aadhaarSha256, CancellationToken cancellationToken = default);
+
+  public Task<User?> GetFirstByRoleAsync(UserRole role, CancellationToken cancellationToken = default);
 }

--- a/src/Aarogya.Infrastructure/Persistence/Repositories/UserRepository.cs
+++ b/src/Aarogya.Infrastructure/Persistence/Repositories/UserRepository.cs
@@ -1,6 +1,8 @@
 using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
 using Aarogya.Domain.Repositories;
 using Aarogya.Domain.Specifications;
+using Microsoft.EntityFrameworkCore;
 
 namespace Aarogya.Infrastructure.Persistence.Repositories;
 
@@ -9,4 +11,33 @@ internal sealed class UserRepository(AarogyaDbContext dbContext)
 {
   public Task<User?> GetByExternalAuthIdAsync(string externalAuthId, CancellationToken cancellationToken = default)
     => FirstOrDefaultAsync(new UserByExternalAuthIdSpecification(externalAuthId), cancellationToken);
+
+  public async Task<User?> GetByPhoneAsync(string phone, CancellationToken cancellationToken = default)
+  {
+    var normalized = phone.Trim();
+    return await dbContext.Users
+      .AsNoTracking()
+      .Where(user => user.Role == UserRole.Patient)
+      .FirstOrDefaultAsync(
+        user => user.Phone != null
+          && user.Phone.Trim() == normalized,
+        cancellationToken);
+  }
+
+  public async Task<User?> GetByAadhaarSha256Async(byte[] aadhaarSha256, CancellationToken cancellationToken = default)
+  {
+    var patients = await dbContext.Users
+      .AsNoTracking()
+      .Where(user => user.Role == UserRole.Patient && user.AadhaarSha256 != null)
+      .ToListAsync(cancellationToken);
+
+    return patients.Find(user => user.AadhaarSha256!.AsSpan().SequenceEqual(aadhaarSha256));
+  }
+
+  public Task<User?> GetFirstByRoleAsync(UserRole role, CancellationToken cancellationToken = default)
+    => dbContext.Users
+      .AsNoTracking()
+      .Where(user => user.Role == role)
+      .OrderBy(user => user.CreatedAt)
+      .FirstOrDefaultAsync(cancellationToken);
 }

--- a/tests/Aarogya.Api.Tests/ReportServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportServiceTests.cs
@@ -58,6 +58,7 @@ public sealed class ReportServiceTests
       Mock.Of<IAccessGrantRepository>(),
       reportRepository.Object,
       Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IPatientNotificationService>(),
       unitOfWork.Object,
       Options.Create(CreateAwsOptions()),
       new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)));
@@ -79,7 +80,7 @@ public sealed class ReportServiceTests
   }
 
   [Fact]
-  public async Task AddForUserAsync_ShouldRequirePatientSub_ForLabTechnicianAsync()
+  public async Task AddForUserAsync_ShouldRequirePatientIdentifier_ForLabTechnicianAsync()
   {
     var uploader = new User
     {
@@ -102,6 +103,7 @@ public sealed class ReportServiceTests
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IReportRepository>(),
       Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IPatientNotificationService>(),
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
@@ -111,7 +113,87 @@ public sealed class ReportServiceTests
     var action = async () => await service.AddForUserAsync("seed-LABTECH-1", request, CancellationToken.None);
 
     await action.Should().ThrowAsync<InvalidOperationException>()
-      .WithMessage("*PatientSub is required*");
+      .WithMessage("*PatientSub, PatientPhone, or PatientAadhaar is required*");
+  }
+
+  [Fact]
+  public async Task AddForUserAsync_ShouldResolvePatientByPhone_AndNotify_WhenLabTechnicianUploadsAsync()
+  {
+    var uploader = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = "seed-LABTECH-1",
+      Role = UserRole.LabTechnician,
+      FirstName = "Lab",
+      LastName = "Tech",
+      Email = "seed.lab@aarogya.dev"
+    };
+
+    var patient = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = "seed-PATIENT-1",
+      Role = UserRole.Patient,
+      FirstName = "Seed",
+      LastName = "Patient",
+      Email = "seed.patient@aarogya.dev",
+      Phone = "+919876543210"
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-LABTECH-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(uploader);
+    userRepository
+      .Setup(x => x.GetByPhoneAsync("+919876543210", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(patient);
+
+    Report? createdReport = null;
+    var reportRepository = new Mock<IReportRepository>();
+    reportRepository
+      .Setup(x => x.GetByReportNumberAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync((Report?)null);
+    reportRepository
+      .Setup(x => x.AddAsync(It.IsAny<Report>(), It.IsAny<CancellationToken>()))
+      .Callback<Report, CancellationToken>((report, _) => createdReport = report)
+      .Returns(Task.CompletedTask);
+
+    var s3Client = new Mock<IAmazonS3>();
+    s3Client
+      .Setup(x => x.GetObjectMetadataAsync(It.IsAny<GetObjectMetadataRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(CreateObjectMetadataResponse("application/pdf", 2048));
+
+    var notificationService = new Mock<IPatientNotificationService>();
+    var service = new ReportService(
+      s3Client.Object,
+      userRepository.Object,
+      Mock.Of<IAccessGrantRepository>(),
+      reportRepository.Object,
+      Mock.Of<IAuditLogRepository>(),
+      notificationService.Object,
+      Mock.Of<IUnitOfWork>(),
+      Options.Create(CreateAwsOptions()),
+      new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)));
+
+    var request = CreateRequest() with
+    {
+      ObjectKey = "reports/seed-LABTECH-1/2026/02/report.pdf",
+      PatientSub = null,
+      PatientPhone = "+919876543210",
+      PatientAadhaar = null
+    };
+
+    _ = await service.AddForUserAsync("seed-LABTECH-1", request, CancellationToken.None);
+
+    createdReport.Should().NotBeNull();
+    createdReport!.PatientId.Should().Be(patient.Id);
+    createdReport.SourceSystem.Should().Be("lab-upload");
+    notificationService.Verify(
+      x => x.NotifyReportUploadedAsync(
+        It.Is<User>(u => u.Id == patient.Id),
+        It.IsAny<Report>(),
+        It.IsAny<CancellationToken>()),
+      Times.Once);
   }
 
   [Fact]
@@ -188,6 +270,7 @@ public sealed class ReportServiceTests
       Mock.Of<IAccessGrantRepository>(),
       reportRepository.Object,
       auditLogRepository.Object,
+      Mock.Of<IPatientNotificationService>(),
       unitOfWork.Object,
       Options.Create(CreateAwsOptions()),
       new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)));
@@ -250,6 +333,7 @@ public sealed class ReportServiceTests
       accessGrantRepository.Object,
       reportRepository.Object,
       Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IPatientNotificationService>(),
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));


### PR DESCRIPTION
## Summary
- extend report upload to support patient lookup by PatientSub, PatientPhone, or PatientAadhaar for lab technician uploads
- support API-key lab identities by resolving a lab technician uploader context for lab-prefixed subjects
- mark lab uploads with source system lab-upload and add upload-origin metadata tag
- add patient notification hook and invoke it after successful lab uploads
- add repository methods and tests for new upload behavior

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #44