### PR TITLE
feat: implement access grant endpoints (#46)

### DIFF
--- a/src/Aarogya.Api/Controllers/V1/AccessGrantsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/AccessGrantsController.cs
@@ -12,7 +12,7 @@ namespace Aarogya.Api.Controllers.V1;
 
 [ApiController]
 [Route("api/v1/access-grants")]
-[Authorize(Policy = AarogyaPolicies.Patient)]
+[Authorize(Policy = AarogyaPolicies.AnyRegisteredRole)]
 [EnableRateLimiting(RateLimitPolicyNames.ApiV1)]
 [SuppressMessage(
   "Performance",
@@ -21,6 +21,7 @@ namespace Aarogya.Api.Controllers.V1;
 public sealed class AccessGrantsController(IAccessGrantService accessGrantService) : ControllerBase
 {
   [HttpGet]
+  [Authorize(Policy = AarogyaPolicies.Patient)]
   [ProducesResponseType(typeof(IReadOnlyList<AccessGrantResponse>), StatusCodes.Status200OK)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
   [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -36,7 +37,25 @@ public sealed class AccessGrantsController(IAccessGrantService accessGrantServic
     return Ok(result);
   }
 
+  [HttpGet("received")]
+  [Authorize(Policy = AarogyaPolicies.Doctor)]
+  [ProducesResponseType(typeof(IReadOnlyList<AccessGrantResponse>), StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status403Forbidden)]
+  public async Task<IActionResult> ListReceivedAccessGrantsAsync(CancellationToken cancellationToken)
+  {
+    var doctorSub = User.GetSubjectOrNull();
+    if (doctorSub is null)
+    {
+      return Unauthorized();
+    }
+
+    var result = await accessGrantService.GetForDoctorAsync(doctorSub, cancellationToken);
+    return Ok(result);
+  }
+
   [HttpPost]
+  [Authorize(Policy = AarogyaPolicies.Patient)]
   [ProducesResponseType(typeof(AccessGrantResponse), StatusCodes.Status201Created)]
   [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -68,6 +87,7 @@ public sealed class AccessGrantsController(IAccessGrantService accessGrantServic
   }
 
   [HttpDelete("{grantId:guid}")]
+  [Authorize(Policy = AarogyaPolicies.Patient)]
   [ProducesResponseType(StatusCodes.Status204NoContent)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
   [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantContracts.cs
+++ b/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantContracts.cs
@@ -20,6 +20,7 @@ public sealed record CreateAccessGrantRequest(
   Justification = "Referenced by public API action signature.")]
 public sealed record AccessGrantResponse(
   Guid GrantId,
+  string PatientSub,
   string DoctorSub,
   bool AllReports,
   IReadOnlyList<Guid> ReportIds,

--- a/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantService.cs
+++ b/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantService.cs
@@ -23,7 +23,28 @@ internal sealed class AccessGrantService(
   public async Task<IReadOnlyList<AccessGrantResponse>> GetForPatientAsync(string patientSub, CancellationToken cancellationToken = default)
   {
     var patient = await ResolvePatientAsync(patientSub, cancellationToken);
+    var now = clock.UtcNow;
     var grants = await accessGrantRepository.ListAsync(new AccessGrantsByPatientSpecification(patient.Id), cancellationToken);
+    return grants
+      .Where(grant => grant.Status == AccessGrantStatus.Active
+        && grant.StartsAt <= now
+        && (grant.ExpiresAt == null || grant.ExpiresAt > now))
+      .Select(MapGrant)
+      .ToArray();
+  }
+
+  public async Task<IReadOnlyList<AccessGrantResponse>> GetForDoctorAsync(string doctorSub, CancellationToken cancellationToken = default)
+  {
+    var doctor = await userRepository.GetByExternalAuthIdAsync(doctorSub, cancellationToken)
+      ?? throw new InvalidOperationException("Authenticated doctor user is not provisioned in the database.");
+    if (doctor.Role != UserRole.Doctor)
+    {
+      throw new InvalidOperationException("Only doctor users can list received grants.");
+    }
+
+    var grants = await accessGrantRepository.ListAsync(
+      new ActiveAccessGrantsByDoctorSpecification(doctor.Id, clock.UtcNow),
+      cancellationToken);
     return grants.Select(MapGrant).ToArray();
   }
 
@@ -36,6 +57,10 @@ internal sealed class AccessGrantService(
     if (doctor.Role != UserRole.Doctor)
     {
       throw new InvalidOperationException("DoctorSub must belong to a doctor user.");
+    }
+    if (string.Equals(patient.ExternalAuthId, doctor.ExternalAuthId, StringComparison.Ordinal))
+    {
+      throw new InvalidOperationException("Cannot grant access to self.");
     }
 
     var now = clock.UtcNow;
@@ -109,6 +134,7 @@ internal sealed class AccessGrantService(
 
     return new AccessGrantResponse(
       grant.Id,
+      patient.ExternalAuthId ?? string.Empty,
       doctor.ExternalAuthId ?? string.Empty,
       request.AllReports,
       reportIds,
@@ -156,6 +182,7 @@ internal sealed class AccessGrantService(
 
     return new AccessGrantResponse(
       grant.Id,
+      grant.Patient.ExternalAuthId ?? string.Empty,
       grant.GrantedToUser.ExternalAuthId ?? string.Empty,
       allReports,
       reportIds,

--- a/src/Aarogya.Api/Features/V1/AccessGrants/IAccessGrantService.cs
+++ b/src/Aarogya.Api/Features/V1/AccessGrants/IAccessGrantService.cs
@@ -10,6 +10,8 @@ public interface IAccessGrantService
 {
   public Task<IReadOnlyList<AccessGrantResponse>> GetForPatientAsync(string patientSub, CancellationToken cancellationToken = default);
 
+  public Task<IReadOnlyList<AccessGrantResponse>> GetForDoctorAsync(string doctorSub, CancellationToken cancellationToken = default);
+
   public Task<AccessGrantResponse> CreateAsync(string patientSub, CreateAccessGrantRequest request, CancellationToken cancellationToken = default);
 
   public Task<bool> RevokeAsync(string patientSub, Guid grantId, CancellationToken cancellationToken = default);

--- a/src/Aarogya.Domain/Specifications/ActiveAccessGrantsByDoctorSpecification.cs
+++ b/src/Aarogya.Domain/Specifications/ActiveAccessGrantsByDoctorSpecification.cs
@@ -1,0 +1,20 @@
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+
+namespace Aarogya.Domain.Specifications;
+
+public sealed class ActiveAccessGrantsByDoctorSpecification : BaseSpecification<AccessGrant>
+{
+  public ActiveAccessGrantsByDoctorSpecification(Guid doctorId, DateTimeOffset nowUtc)
+    : base(grant =>
+      grant.GrantedToUserId == doctorId
+      && grant.Status == AccessGrantStatus.Active
+      && grant.StartsAt <= nowUtc
+      && (grant.ExpiresAt == null || grant.ExpiresAt > nowUtc))
+  {
+    AddInclude(grant => grant.Patient);
+    AddInclude(grant => grant.GrantedToUser);
+    ApplyOrderByDescending(grant => grant.CreatedAt);
+    ApplyAsNoTracking();
+  }
+}

--- a/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
@@ -56,6 +56,7 @@ public sealed class AccessGrantServiceTests
       new CreateAccessGrantRequest("seed-DOCTOR-1", true, null, "care-coordination", null),
       CancellationToken.None);
 
+    result.PatientSub.Should().Be("seed-PATIENT-1");
     result.AllReports.Should().BeTrue();
     result.ReportIds.Should().BeEmpty();
     result.Purpose.Should().Be("care-coordination");
@@ -137,6 +138,79 @@ public sealed class AccessGrantServiceTests
     revoked.Should().BeTrue();
     grant.Status.Should().Be(AccessGrantStatus.Revoked);
     unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task GetForDoctorAsync_ShouldReturnActiveGrantsAsync()
+  {
+    var now = new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero);
+    var doctor = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-DOCTOR-1", Role = UserRole.Doctor };
+    var patient = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-PATIENT-1", Role = UserRole.Patient };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-DOCTOR-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(doctor);
+
+    var accessGrantRepository = new Mock<IAccessGrantRepository>();
+    accessGrantRepository
+      .Setup(x => x.ListAsync(It.IsAny<ISpecification<AccessGrant>>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(
+      [
+        new AccessGrant
+        {
+          Id = Guid.NewGuid(),
+          Patient = patient,
+          GrantedToUser = doctor,
+          Scope = new Domain.ValueObjects.AccessGrantScope(),
+          GrantReason = "active",
+          StartsAt = now.AddDays(-1),
+          ExpiresAt = now.AddDays(7),
+          Status = AccessGrantStatus.Active
+        }
+      ]);
+
+    var service = new AccessGrantService(
+      userRepository.Object,
+      Mock.Of<IReportRepository>(),
+      accessGrantRepository.Object,
+      Mock.Of<IUnitOfWork>(),
+      Options.Create(new AccessGrantOptions()),
+      new FixedUtcClock(now));
+
+    var result = await service.GetForDoctorAsync("seed-DOCTOR-1", CancellationToken.None);
+
+    result.Should().HaveCount(1);
+    result[0].PatientSub.Should().Be("seed-PATIENT-1");
+    result[0].DoctorSub.Should().Be("seed-DOCTOR-1");
+  }
+
+  [Fact]
+  public async Task CreateAsync_ShouldRejectSelfGrantAsync()
+  {
+    var patient = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-PATIENT-1", Role = UserRole.Patient };
+    var doctor = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-PATIENT-1", Role = UserRole.Doctor };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .SetupSequence(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(patient)
+      .ReturnsAsync(doctor);
+
+    var service = new AccessGrantService(
+      userRepository.Object,
+      Mock.Of<IReportRepository>(),
+      Mock.Of<IAccessGrantRepository>(),
+      Mock.Of<IUnitOfWork>(),
+      Options.Create(new AccessGrantOptions()),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var action = async () => await service.CreateAsync(
+      "seed-PATIENT-1",
+      new CreateAccessGrantRequest("seed-PATIENT-1", true, null, "self", DateTimeOffset.UtcNow.AddDays(2)),
+      CancellationToken.None);
+
+    await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Cannot grant access to self*");
   }
 
   private sealed class FixedUtcClock(DateTimeOffset utcNow) : IUtcClock


### PR DESCRIPTION
## Summary
- complete access grant endpoint behavior for patient and doctor flows
- add doctor endpoint to list grants received from patients
- return active grants in list responses and keep revoke as soft delete
- enforce self-grant prevention and active-scope grant mapping updates
- expand access grant service tests for doctor listing and self-grant validation

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #46