### PR TITLE
feat: configure transport TLS enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,26 @@ Notes:
 - Local/dev: set `UseAwsKms=false` and provide `LocalDataKey`.
 - Always set a strong `BlindIndexKey` via user-secrets or environment variables.
 
+### Transport Security (TLS)
+Issue #49 adds transport-level TLS enforcement controls for production paths:
+- PostgreSQL connection must use `SSL Mode=Require|VerifyCA|VerifyFull`
+- Redis connection must include `ssl=true`
+- AWS `ServiceUrl` must use `https://` when LocalStack is disabled
+
+Configuration:
+```json
+{
+  "TransportSecurity": {
+    "EnforceTls13": true
+  }
+}
+```
+
+Notes:
+- `TransportSecurity:EnforceTls13=true` is enabled in `appsettings.json` (production baseline).
+- `appsettings.Development.json` disables enforcement for local Docker/Aspire environments that use non-TLS local endpoints.
+- In production, avoid `Trust Server Certificate=true` in PostgreSQL connection strings.
+
 ### Aadhaar Vault Configuration
 Issue #19 introduces a dedicated Aadhaar vault schema with:
 - `aadhaar_vault.aadhaar_records` for encrypted Aadhaar + SHA-256 lookup + reference token

--- a/src/Aarogya.Api/Configuration/StartupExtensions.cs
+++ b/src/Aarogya.Api/Configuration/StartupExtensions.cs
@@ -219,6 +219,12 @@ public static class StartupExtensions
       violations.Add("Aws:ServiceUrl must be a valid absolute HTTP/HTTPS URL");
     }
 
+    var enforceTls13 = configuration.GetSection("TransportSecurity").GetSection("EnforceTls13").Get<bool?>() ?? false;
+    if (enforceTls13)
+    {
+      AddTransportSecurityViolations(configuration, violations);
+    }
+
     var corsOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
     foreach (var origin in corsOrigins)
     {
@@ -232,9 +238,46 @@ public static class StartupExtensions
     return violations;
   }
 
+  private static void AddTransportSecurityViolations(IConfiguration configuration, List<string> violations)
+  {
+    var defaultConnection = configuration["ConnectionStrings:DefaultConnection"] ?? string.Empty;
+    if (!HasSecurePostgreSqlSslMode(defaultConnection))
+    {
+      violations.Add("ConnectionStrings:DefaultConnection must set SSL Mode=Require|VerifyCA|VerifyFull when TransportSecurity:EnforceTls13=true");
+    }
+
+    if (defaultConnection.Contains("Trust Server Certificate=true", StringComparison.OrdinalIgnoreCase))
+    {
+      violations.Add("ConnectionStrings:DefaultConnection cannot trust server certificates when TransportSecurity:EnforceTls13=true");
+    }
+
+    var redisConnection = configuration["ConnectionStrings:Redis"] ?? string.Empty;
+    if (!string.IsNullOrWhiteSpace(redisConnection)
+      && !redisConnection.Contains("ssl=true", StringComparison.OrdinalIgnoreCase))
+    {
+      violations.Add("ConnectionStrings:Redis must include ssl=true when TransportSecurity:EnforceTls13=true");
+    }
+
+    var useLocalStack = configuration.GetSection("Aws:UseLocalStack").Get<bool?>() ?? false;
+    var awsServiceUrl = configuration["Aws:ServiceUrl"];
+    if (!useLocalStack
+      && !string.IsNullOrWhiteSpace(awsServiceUrl)
+      && !awsServiceUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+    {
+      violations.Add("Aws:ServiceUrl must use HTTPS when TransportSecurity:EnforceTls13=true");
+    }
+  }
+
   private static bool ContainsAny(string value, params string[] patterns)
   {
     return Array.Exists(patterns, pattern => value.Contains(pattern, StringComparison.OrdinalIgnoreCase));
+  }
+
+  private static bool HasSecurePostgreSqlSslMode(string connectionString)
+  {
+    return connectionString.Contains("ssl mode=require", StringComparison.OrdinalIgnoreCase)
+      || connectionString.Contains("ssl mode=verifyca", StringComparison.OrdinalIgnoreCase)
+      || connectionString.Contains("ssl mode=verifyfull", StringComparison.OrdinalIgnoreCase);
   }
 
   private static bool IsMissingConfigurationValue(string? value)

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -10,6 +10,7 @@ using Aarogya.Infrastructure;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
 using Serilog;
@@ -163,6 +164,12 @@ var rateLimitingOptions = builder.Configuration
   .GetSection(RateLimitingOptions.SectionName)
   .Get<RateLimitingOptions>() ?? new RateLimitingOptions();
 builder.Services.AddAarogyaRateLimiting(rateLimitingOptions);
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+  options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+  options.KnownNetworks.Clear();
+  options.KnownProxies.Clear();
+});
 
 var app = builder.Build();
 
@@ -180,8 +187,13 @@ app.UseSwaggerUI(c =>
 
 app.UseAarogyaRequestLogging();
 app.UseAarogyaApiVersioning();
+app.UseForwardedHeaders();
 
 app.UseHttpsRedirection();
+if (!app.Environment.IsDevelopment())
+{
+  app.UseHsts();
+}
 app.UseCors("AarogyaPolicy");
 app.UseAuthentication();
 if (rateLimitingOptions.EnableRateLimiting)

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -157,6 +157,9 @@
     "AutoMigrateOnStartup": true,
     "HealthCheckTimeoutSeconds": 5
   },
+  "TransportSecurity": {
+    "EnforceTls13": false
+  },
   "HealthChecks": {
     "EnableDetailedOutput": true
   },

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -161,6 +161,9 @@
     "AutoMigrateOnStartup": false,
     "HealthCheckTimeoutSeconds": 5
   },
+  "TransportSecurity": {
+    "EnforceTls13": true
+  },
   "RateLimiting": {
     "EnableRateLimiting": true,
     "Auth": {

--- a/src/Aarogya.Api/secrets.template.json
+++ b/src/Aarogya.Api/secrets.template.json
@@ -5,6 +5,7 @@
 
   "ConnectionStrings:DefaultConnection": "Host=localhost;Port=5432;Database=aarogya;Username=aarogya;Password=your_password;Include Error Detail=true",
   "ConnectionStrings:Redis": "localhost:6379,abortConnect=false,connectTimeout=5000",
+  "TransportSecurity:EnforceTls13": "false",
 
   "Aws:AccessKey": "your-aws-access-key-or-test-for-localstack",
   "Aws:SecretKey": "your-aws-secret-key-or-test-for-localstack",

--- a/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
+++ b/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Amazon;
 using Amazon.CognitoIdentityProvider;
 using Amazon.Extensions.NETCore.Setup;
@@ -13,6 +14,10 @@ namespace Aarogya.Infrastructure.Aws;
 
 public static class AwsServiceRegistration
 {
+  [SuppressMessage(
+    "Maintainability",
+    "CA1502:Avoid excessive complexity",
+    Justification = "Service registration branches are explicit by AWS client type and environment mode.")]
   public static IServiceCollection AddAwsServices(
     this IServiceCollection services,
     IConfiguration configuration)
@@ -23,8 +28,15 @@ public static class AwsServiceRegistration
     var region = awsSection["Region"] ?? "ap-south-1";
     var serviceUrl = awsSection["ServiceUrl"];
     var useLocalStack = awsSection.GetSection("UseLocalStack").Get<bool?>() ?? false;
+    var enforceTls13 = configuration.GetSection("TransportSecurity").GetSection("EnforceTls13").Get<bool?>() ?? false;
     var accessKey = awsSection["AccessKey"] ?? string.Empty;
     var secretKey = awsSection["SecretKey"] ?? string.Empty;
+    var hasServiceUrl = !string.IsNullOrWhiteSpace(serviceUrl);
+
+    if (enforceTls13 && !useLocalStack && hasServiceUrl && !serviceUrl!.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+    {
+      throw new InvalidOperationException("Aws:ServiceUrl must use HTTPS when TransportSecurity:EnforceTls13=true.");
+    }
 
     var awsOptions = new AWSOptions
     {
@@ -40,15 +52,17 @@ public static class AwsServiceRegistration
     services.AddDefaultAWSOptions(awsOptions);
 
     // Register S3 client
-    if (useLocalStack && !string.IsNullOrWhiteSpace(serviceUrl))
+    if (useLocalStack && hasServiceUrl)
     {
+      var useHttp = serviceUrl!.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
       services.AddSingleton<IAmazonS3>(_ => new AmazonS3Client(
         awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
         new AmazonS3Config
         {
           RegionEndpoint = awsOptions.Region,
           ServiceURL = serviceUrl,
-          ForcePathStyle = true
+          ForcePathStyle = true,
+          UseHttp = useHttp
         }));
     }
     else
@@ -57,14 +71,16 @@ public static class AwsServiceRegistration
     }
 
     // Register SES v2 client
-    if (useLocalStack && !string.IsNullOrWhiteSpace(serviceUrl))
+    if (useLocalStack && hasServiceUrl)
     {
+      var useHttp = serviceUrl!.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
       services.AddSingleton<IAmazonSimpleEmailServiceV2>(_ => new AmazonSimpleEmailServiceV2Client(
         awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
         new AmazonSimpleEmailServiceV2Config
         {
           RegionEndpoint = awsOptions.Region,
-          ServiceURL = serviceUrl
+          ServiceURL = serviceUrl,
+          UseHttp = useHttp
         }));
     }
     else
@@ -73,14 +89,16 @@ public static class AwsServiceRegistration
     }
 
     // Register SQS client
-    if (useLocalStack && !string.IsNullOrWhiteSpace(serviceUrl))
+    if (useLocalStack && hasServiceUrl)
     {
+      var useHttp = serviceUrl!.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
       services.AddSingleton<IAmazonSQS>(_ => new AmazonSQSClient(
         awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
         new AmazonSQSConfig
         {
           RegionEndpoint = awsOptions.Region,
-          ServiceURL = serviceUrl
+          ServiceURL = serviceUrl,
+          UseHttp = useHttp
         }));
     }
     else
@@ -89,14 +107,16 @@ public static class AwsServiceRegistration
     }
 
     // Register AWS KMS client
-    if (useLocalStack && !string.IsNullOrWhiteSpace(serviceUrl))
+    if (useLocalStack && hasServiceUrl)
     {
+      var useHttp = serviceUrl!.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
       services.AddSingleton<IAmazonKeyManagementService>(_ => new AmazonKeyManagementServiceClient(
         awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
         new AmazonKeyManagementServiceConfig
         {
           RegionEndpoint = awsOptions.Region,
-          ServiceURL = serviceUrl
+          ServiceURL = serviceUrl,
+          UseHttp = useHttp
         }));
     }
     else
@@ -105,14 +125,16 @@ public static class AwsServiceRegistration
     }
 
     // Register Cognito Identity Provider client
-    if (useLocalStack && !string.IsNullOrWhiteSpace(serviceUrl))
+    if (useLocalStack && hasServiceUrl)
     {
+      var useHttp = serviceUrl!.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
       services.AddSingleton<IAmazonCognitoIdentityProvider>(_ => new AmazonCognitoIdentityProviderClient(
         awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
         new AmazonCognitoIdentityProviderConfig
         {
           RegionEndpoint = awsOptions.Region,
-          ServiceURL = serviceUrl
+          ServiceURL = serviceUrl,
+          UseHttp = useHttp
         }));
     }
     else

--- a/src/Aarogya.Infrastructure/DependencyInjection.cs
+++ b/src/Aarogya.Infrastructure/DependencyInjection.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace Aarogya.Infrastructure;
 
@@ -38,6 +39,7 @@ public static class DependencyInjection
     var maxRetryCount = dbSection.GetSection("MaxRetryCount").Get<int?>() ?? 3;
     var maxRetryDelaySeconds = dbSection.GetSection("MaxRetryDelaySeconds").Get<int?>() ?? 5;
     var healthCheckTimeoutSeconds = dbSection.GetSection("HealthCheckTimeoutSeconds").Get<int?>() ?? 5;
+    var enforceTls13 = configuration.GetSection("TransportSecurity").GetSection("EnforceTls13").Get<bool?>() ?? false;
     var redisSection = configuration.GetSection("Redis");
     var redisConnectionString = configuration.GetConnectionString("Redis");
     var redisInstanceName = redisSection.GetSection("InstanceName").Get<string>() ?? "aarogya_";
@@ -45,6 +47,15 @@ public static class DependencyInjection
     var redisConnectTimeout = redisSection.GetSection("ConnectTimeoutMilliseconds").Get<int?>() ?? 5000;
     var redisConnectRetry = redisSection.GetSection("ConnectRetry").Get<int?>() ?? 3;
     var redisSyncTimeout = redisSection.GetSection("SyncTimeoutMilliseconds").Get<int?>() ?? 5000;
+
+    if (enforceTls13)
+    {
+      var secureConnectionBuilder = new NpgsqlConnectionStringBuilder(connectionString)
+      {
+        SslMode = SslMode.Require
+      };
+      connectionString = secureConnectionBuilder.ConnectionString;
+    }
 
     services.AddDbContextPool<AarogyaDbContext>(options =>
     {
@@ -111,6 +122,10 @@ public static class DependencyInjection
         redisConfiguration.SyncTimeout = redisSyncTimeout;
         redisConfiguration.DefaultDatabase = redisDatabase;
         redisConfiguration.AbortOnConnectFail = false;
+        if (enforceTls13)
+        {
+          redisConfiguration.Ssl = true;
+        }
         options.ConfigurationOptions = redisConfiguration;
       });
     }

--- a/tests/Aarogya.Api.Tests/ConfigurationValidationTests.cs
+++ b/tests/Aarogya.Api.Tests/ConfigurationValidationTests.cs
@@ -127,6 +127,50 @@ public class ConfigurationValidationTests
     action.Should().NotThrow();
   }
 
+  [Fact]
+  public void ValidateRequiredConfiguration_ShouldThrowInProduction_WhenTlsEnforcementEnabledAndConnectionsAreInsecure()
+  {
+    var values = WithDefaultsForSocialProviderConfiguration(new Dictionary<string, string?>
+    {
+      ["ConnectionStrings:DefaultConnection"] = "Host=db;Port=5432;Database=aarogya;Username=aarogya;Password=strong-password",
+      ["ConnectionStrings:Redis"] = "redis:6379,abortConnect=false",
+      ["Aws:Cognito:UserPoolId"] = "ap-south-1_examplePoolId",
+      ["Aws:Cognito:AppClientId"] = "example-app-client-id",
+      ["Aws:UseLocalStack"] = "false",
+      ["Aws:ServiceUrl"] = "http://s3.ap-south-1.amazonaws.com",
+      ["TransportSecurity:EnforceTls13"] = "true"
+    });
+    var configuration = BuildConfiguration(values);
+
+    var action = () => StartupExtensions.ValidateRequiredConfiguration(configuration, new TestHostEnvironment("Production"));
+
+    action.Should().Throw<InvalidOperationException>()
+      .WithMessage("*DefaultConnection must set SSL Mode*")
+      .WithMessage("*ConnectionStrings:Redis must include ssl=true*")
+      .WithMessage("*Aws:ServiceUrl must use HTTPS*");
+  }
+
+  [Fact]
+  public void ValidateRequiredConfiguration_ShouldNotThrowInProduction_WhenTlsEnforcementEnabledAndConnectionsAreSecure()
+  {
+    var values = WithDefaultsForSocialProviderConfiguration(new Dictionary<string, string?>
+    {
+      ["ConnectionStrings:DefaultConnection"] =
+        "Host=db;Port=5432;Database=aarogya;Username=aarogya;Password=strong-password;SSL Mode=VerifyFull;Trust Server Certificate=false",
+      ["ConnectionStrings:Redis"] = "cache.example.com:6380,ssl=true,abortConnect=false",
+      ["Aws:Cognito:UserPoolId"] = "ap-south-1_examplePoolId",
+      ["Aws:Cognito:AppClientId"] = "example-app-client-id",
+      ["Aws:UseLocalStack"] = "false",
+      ["Aws:ServiceUrl"] = "https://s3.ap-south-1.amazonaws.com",
+      ["TransportSecurity:EnforceTls13"] = "true"
+    });
+    var configuration = BuildConfiguration(values);
+
+    var action = () => StartupExtensions.ValidateRequiredConfiguration(configuration, new TestHostEnvironment("Production"));
+
+    action.Should().NotThrow();
+  }
+
   private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
   {
     return new ConfigurationBuilder()


### PR DESCRIPTION
## Summary
- add transport security enforcement toggle (`TransportSecurity:EnforceTls13`)
- enforce secure DB/Redis client settings when enabled
- validate production config for secure PostgreSQL, Redis, and AWS service URLs
- configure forwarded headers + HSTS to support HTTPS behind ALB/proxies
- add transport security tests and update README guidance

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #49