### PR TITLE
feat: implement CORS and security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,33 @@ Notes:
 - `appsettings.Development.json` disables enforcement for local Docker/Aspire environments that use non-TLS local endpoints.
 - In production, avoid `Trust Server Certificate=true` in PostgreSQL connection strings.
 
+### Security Headers and CORS
+Issue #50 adds strict response hardening for API responses:
+- `Content-Security-Policy`
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: no-referrer`
+- HSTS configured with `preload` + `includeSubDomains`
+
+Configuration:
+```json
+{
+  "SecurityHeaders": {
+    "ContentSecurityPolicy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; object-src 'none'",
+    "XFrameOptions": "DENY",
+    "XContentTypeOptions": "nosniff",
+    "ReferrerPolicy": "no-referrer",
+    "HstsIncludeSubDomains": true,
+    "HstsPreload": true,
+    "HstsMaxAgeDays": 730
+  }
+}
+```
+
+Notes:
+- CORS is allow-list based via `Cors:AllowedOrigins`; origins not listed are blocked.
+- Preflight cache duration is set with `Access-Control-Max-Age` (10 minutes).
+
 ### Aadhaar Vault Configuration
 Issue #19 introduces a dedicated Aadhaar vault schema with:
 - `aadhaar_vault.aadhaar_records` for encrypted Aadhaar + SHA-256 lookup + reference token

--- a/src/Aarogya.Api/Configuration/SecurityHeadersOptions.cs
+++ b/src/Aarogya.Api/Configuration/SecurityHeadersOptions.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Aarogya.Api.Configuration;
+
+public sealed class SecurityHeadersOptions
+{
+  public const string SectionName = "SecurityHeaders";
+
+  [Required]
+  public string ContentSecurityPolicy { get; set; } = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; object-src 'none'";
+
+  [Required]
+  public string XFrameOptions { get; set; } = "DENY";
+
+  [Required]
+  public string XContentTypeOptions { get; set; } = "nosniff";
+
+  [Required]
+  public string ReferrerPolicy { get; set; } = "no-referrer";
+
+  public bool HstsIncludeSubDomains { get; set; } = true;
+
+  public bool HstsPreload { get; set; } = true;
+
+  [Range(1, 3650)]
+  public int HstsMaxAgeDays { get; set; } = 730;
+}

--- a/src/Aarogya.Api/Configuration/StartupExtensions.cs
+++ b/src/Aarogya.Api/Configuration/StartupExtensions.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Aarogya.Infrastructure.Persistence;
 using Aarogya.Infrastructure.Seeding;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Serilog;
 using Serilog.Events;
 
@@ -23,6 +24,7 @@ public static class StartupExtensions
         if (origins.Length > 0)
         {
           policy.WithOrigins(origins);
+          policy.SetPreflightMaxAge(TimeSpan.FromMinutes(10));
 
           if (corsConfig!.AllowCredentials)
           {
@@ -37,6 +39,23 @@ public static class StartupExtensions
 
         policy.AllowAnyMethod().AllowAnyHeader();
       });
+    });
+
+    return services;
+  }
+
+  public static IServiceCollection AddAarogyaSecurityHeaders(
+    this IServiceCollection services,
+    IConfiguration configuration)
+  {
+    var options = configuration.GetSection(SecurityHeadersOptions.SectionName).Get<SecurityHeadersOptions>()
+      ?? new SecurityHeadersOptions();
+
+    services.AddHsts(hsts =>
+    {
+      hsts.Preload = options.HstsPreload;
+      hsts.IncludeSubDomains = options.HstsIncludeSubDomains;
+      hsts.MaxAge = TimeSpan.FromDays(options.HstsMaxAgeDays);
     });
 
     return services;
@@ -68,6 +87,31 @@ public static class StartupExtensions
           httpContext.Request.Headers.ContainsKey("Authorization")
           || httpContext.Request.Headers.ContainsKey("Cookie"));
       };
+    });
+
+    return app;
+  }
+
+  public static IApplicationBuilder UseAarogyaSecurityHeaders(this IApplicationBuilder app)
+  {
+    var options = app.ApplicationServices.GetRequiredService<IOptions<SecurityHeadersOptions>>().Value;
+
+    app.Use(async (context, next) =>
+    {
+      context.Response.OnStarting(static state =>
+      {
+        var (httpContext, securityHeadersOptions) = ((HttpContext, SecurityHeadersOptions))state;
+        var headers = httpContext.Response.Headers;
+
+        headers["Content-Security-Policy"] = securityHeadersOptions.ContentSecurityPolicy;
+        headers["X-Frame-Options"] = securityHeadersOptions.XFrameOptions;
+        headers["X-Content-Type-Options"] = securityHeadersOptions.XContentTypeOptions;
+        headers["Referrer-Policy"] = securityHeadersOptions.ReferrerPolicy;
+
+        return Task.CompletedTask;
+      }, (context, options));
+
+      await next();
     });
 
     return app;

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -52,6 +52,11 @@ builder.Services
   .BindConfiguration(CorsOptions.SectionName);
 
 builder.Services
+  .AddOptionsWithValidateOnStart<SecurityHeadersOptions>()
+  .BindConfiguration(SecurityHeadersOptions.SectionName)
+  .ValidateDataAnnotations();
+
+builder.Services
   .AddOptionsWithValidateOnStart<DatabaseOptions>()
   .BindConfiguration(DatabaseOptions.SectionName)
   .ValidateDataAnnotations();
@@ -158,6 +163,7 @@ builder.Services.AddCognitoJwtAuthentication(builder.Configuration);
 builder.Services.AddAarogyaAuthorization();
 
 builder.Services.AddAarogyaCorsPolicy(builder.Configuration);
+builder.Services.AddAarogyaSecurityHeaders(builder.Configuration);
 builder.Services.AddV1FeatureServices();
 
 var rateLimitingOptions = builder.Configuration
@@ -188,6 +194,7 @@ app.UseSwaggerUI(c =>
 app.UseAarogyaRequestLogging();
 app.UseAarogyaApiVersioning();
 app.UseForwardedHeaders();
+app.UseAarogyaSecurityHeaders();
 
 app.UseHttpsRedirection();
 if (!app.Environment.IsDevelopment())

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -160,6 +160,15 @@
   "TransportSecurity": {
     "EnforceTls13": false
   },
+  "SecurityHeaders": {
+    "ContentSecurityPolicy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; object-src 'none'",
+    "XFrameOptions": "DENY",
+    "XContentTypeOptions": "nosniff",
+    "ReferrerPolicy": "no-referrer",
+    "HstsIncludeSubDomains": true,
+    "HstsPreload": true,
+    "HstsMaxAgeDays": 730
+  },
   "HealthChecks": {
     "EnableDetailedOutput": true
   },

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -164,6 +164,15 @@
   "TransportSecurity": {
     "EnforceTls13": true
   },
+  "SecurityHeaders": {
+    "ContentSecurityPolicy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; object-src 'none'",
+    "XFrameOptions": "DENY",
+    "XContentTypeOptions": "nosniff",
+    "ReferrerPolicy": "no-referrer",
+    "HstsIncludeSubDomains": true,
+    "HstsPreload": true,
+    "HstsMaxAgeDays": 730
+  },
   "RateLimiting": {
     "EnableRateLimiting": true,
     "Auth": {

--- a/src/Aarogya.Api/secrets.template.json
+++ b/src/Aarogya.Api/secrets.template.json
@@ -6,6 +6,7 @@
   "ConnectionStrings:DefaultConnection": "Host=localhost;Port=5432;Database=aarogya;Username=aarogya;Password=your_password;Include Error Detail=true",
   "ConnectionStrings:Redis": "localhost:6379,abortConnect=false,connectTimeout=5000",
   "TransportSecurity:EnforceTls13": "false",
+  "SecurityHeaders:ContentSecurityPolicy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'; object-src 'none'",
 
   "Aws:AccessKey": "your-aws-access-key-or-test-for-localstack",
   "Aws:SecretKey": "your-aws-secret-key-or-test-for-localstack",


### PR DESCRIPTION
## Summary
- add global API security headers middleware for CSP, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy
- add configurable `SecurityHeaders` options with strict defaults
- configure HSTS with preload and includeSubDomains via `AddHsts`
- tighten CORS policy behavior with preflight max-age and existing allow-list origin model
- update runtime configuration templates and README guidance

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #50