### PR TITLE
feat: add centralized audit logging service (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,20 @@ Additional guardrails:
 - JSON input is constrained to declared DTO contracts via explicit `System.Text.Json` type resolver configuration
 - source guardrail tests validate that raw SQL execution patterns are not introduced in application code
 
+### Audit Logging
+Issue #52 adds a centralized audit logging service for PII/medical-data access workflows.
+
+Captured fields:
+- who: `actor_user_id`, `actor_role`
+- what: `action`, `resource_type`, `resource_id`
+- when: `occurredAtUtc` and `occurredAtIst` (stored in audit details)
+- where: request path/method, client IP, user-agent
+
+Notes:
+- audit records are persisted in `audit_logs` through `IAuditLogRepository`
+- application logs emit structured audit events via Serilog/`ILogger`; in containerized AWS deployments these logs flow to CloudWatch through runtime log drivers
+- audit payloads avoid raw PII values in summary/messages
+
 ### Aadhaar Vault Configuration
 Issue #19 introduces a dedicated Aadhaar vault schema with:
 - `aadhaar_vault.aadhaar_records` for encrypted Aadhaar + SHA-256 lookup + reference token

--- a/src/Aarogya.Api/Auditing/AuditLoggingService.cs
+++ b/src/Aarogya.Api/Auditing/AuditLoggingService.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using System.Globalization;
+using Aarogya.Api.Authentication;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.ValueObjects;
+
+namespace Aarogya.Api.Auditing;
+
+internal sealed class AuditLoggingService(
+  IAuditLogRepository auditLogRepository,
+  IUnitOfWork unitOfWork,
+  IHttpContextAccessor httpContextAccessor,
+  IUtcClock clock,
+  ILogger<AuditLoggingService> logger)
+  : IAuditLoggingService
+{
+  private static readonly Lazy<TimeZoneInfo> IstTimeZone = new(ResolveIstTimeZone);
+
+  public async Task LogDataAccessAsync(
+    User actor,
+    string action,
+    string resourceType,
+    Guid? resourceId,
+    int resultStatus,
+    IReadOnlyDictionary<string, string>? data = null,
+    CancellationToken cancellationToken = default)
+  {
+    var now = clock.UtcNow;
+    var request = httpContextAccessor.HttpContext?.Request;
+    var occurredAtIst = TimeZoneInfo.ConvertTime(now, IstTimeZone.Value);
+
+    var details = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+      ["occurredAtUtc"] = now.ToString("O", CultureInfo.InvariantCulture),
+      ["occurredAtIst"] = occurredAtIst.ToString("O", CultureInfo.InvariantCulture)
+    };
+
+    if (data is not null)
+    {
+      foreach (var pair in data)
+      {
+        details[pair.Key] = pair.Value;
+      }
+    }
+
+    var auditLog = new AuditLog
+    {
+      Id = Guid.NewGuid(),
+      OccurredAt = now,
+      ActorUserId = actor.Id,
+      ActorRole = actor.Role,
+      Action = action,
+      EntityType = resourceType,
+      EntityId = resourceId,
+      CorrelationId = TryResolveCorrelationId(request?.HttpContext),
+      RequestPath = request?.Path.Value,
+      RequestMethod = request?.Method,
+      ClientIp = request?.HttpContext.Connection.RemoteIpAddress,
+      UserAgent = request?.Headers.UserAgent.ToString(),
+      ResultStatus = resultStatus,
+      Details = new AuditLogDetails
+      {
+        Summary = $"{resourceType} access captured.",
+        Data = details
+      }
+    };
+
+    await auditLogRepository.AddAsync(auditLog, cancellationToken);
+    await unitOfWork.SaveChangesAsync(cancellationToken);
+
+    logger.LogInformation(
+      "AuditEvent ActorUserId={ActorUserId} ActorRole={ActorRole} Action={Action} ResourceType={ResourceType} ResourceId={ResourceId} Status={Status} RequestPath={RequestPath}",
+      auditLog.ActorUserId,
+      auditLog.ActorRole,
+      auditLog.Action,
+      auditLog.EntityType,
+      auditLog.EntityId,
+      auditLog.ResultStatus,
+      auditLog.RequestPath);
+  }
+
+  private static Guid? TryResolveCorrelationId(HttpContext? context)
+  {
+    if (context is null)
+    {
+      return null;
+    }
+
+    if (Activity.Current is not null && Guid.TryParse(Activity.Current.TraceId.ToString()[..32], out var traceGuid))
+    {
+      return traceGuid;
+    }
+
+    return Guid.TryParse(context.TraceIdentifier, out var correlationId)
+      ? correlationId
+      : null;
+  }
+
+  private static TimeZoneInfo ResolveIstTimeZone()
+  {
+    try
+    {
+      return TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata");
+    }
+    catch (TimeZoneNotFoundException)
+    {
+      return TimeZoneInfo.FindSystemTimeZoneById("India Standard Time");
+    }
+  }
+}

--- a/src/Aarogya.Api/Auditing/IAuditLoggingService.cs
+++ b/src/Aarogya.Api/Auditing/IAuditLoggingService.cs
@@ -1,0 +1,19 @@
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Api.Auditing;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Exposed for unit test mocking and composition root registration.")]
+public interface IAuditLoggingService
+{
+  public Task LogDataAccessAsync(
+    User actor,
+    string action,
+    string resourceType,
+    Guid? resourceId,
+    int resultStatus,
+    IReadOnlyDictionary<string, string>? data = null,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantService.cs
+++ b/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantService.cs
@@ -1,3 +1,4 @@
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Configuration;
 using Aarogya.Api.Security;
@@ -15,6 +16,7 @@ internal sealed class AccessGrantService(
   IReportRepository reportRepository,
   IAccessGrantRepository accessGrantRepository,
   IUnitOfWork unitOfWork,
+  IAuditLoggingService auditLoggingService,
   IOptions<AccessGrantOptions> options,
   IUtcClock clock)
   : IAccessGrantService
@@ -26,6 +28,18 @@ internal sealed class AccessGrantService(
     var patient = await ResolvePatientAsync(patientSub, cancellationToken);
     var now = clock.UtcNow;
     var grants = await accessGrantRepository.ListAsync(new AccessGrantsByPatientSpecification(patient.Id), cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      patient,
+      "access_grant.list.patient",
+      "access_grant",
+      null,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["count"] = grants.Count.ToString()
+      },
+      cancellationToken);
+
     return grants
       .Where(grant => grant.Status == AccessGrantStatus.Active
         && grant.StartsAt <= now
@@ -46,6 +60,18 @@ internal sealed class AccessGrantService(
     var grants = await accessGrantRepository.ListAsync(
       new ActiveAccessGrantsByDoctorSpecification(doctor.Id, clock.UtcNow),
       cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      doctor,
+      "access_grant.list.doctor",
+      "access_grant",
+      null,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["count"] = grants.Count.ToString()
+      },
+      cancellationToken);
+
     return grants.Select(MapGrant).ToArray();
   }
 
@@ -133,6 +159,18 @@ internal sealed class AccessGrantService(
 
     await accessGrantRepository.AddAsync(grant, cancellationToken);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      patient,
+      "access_grant.created",
+      "access_grant",
+      grant.Id,
+      201,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["doctorUserId"] = doctor.Id.ToString("D"),
+        ["allReports"] = request.AllReports.ToString()
+      },
+      cancellationToken);
 
     return new AccessGrantResponse(
       grant.Id,
@@ -161,6 +199,13 @@ internal sealed class AccessGrantService(
     grant.RevokedAt = clock.UtcNow;
     accessGrantRepository.Update(grant);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      patient,
+      "access_grant.revoked",
+      "access_grant",
+      grant.Id,
+      200,
+      cancellationToken: cancellationToken);
     return true;
   }
 

--- a/src/Aarogya.Api/Features/V1/EmergencyContacts/EmergencyContactService.cs
+++ b/src/Aarogya.Api/Features/V1/EmergencyContacts/EmergencyContactService.cs
@@ -1,3 +1,4 @@
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Security;
 using Aarogya.Domain.Entities;
@@ -11,6 +12,7 @@ internal sealed class EmergencyContactService(
   IUserRepository userRepository,
   IEmergencyContactRepository emergencyContactRepository,
   IUnitOfWork unitOfWork,
+  IAuditLoggingService auditLoggingService,
   IUtcClock clock)
   : IEmergencyContactService
 {
@@ -22,6 +24,18 @@ internal sealed class EmergencyContactService(
   {
     var patient = await ResolvePatientAsync(userSub, cancellationToken);
     var contacts = await emergencyContactRepository.ListByUserAsync(patient.Id, cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      patient,
+      "emergency_contact.listed",
+      "emergency_contact",
+      null,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["count"] = contacts.Count.ToString()
+      },
+      cancellationToken);
+
     return contacts.Select(Map).ToArray();
   }
 
@@ -53,6 +67,13 @@ internal sealed class EmergencyContactService(
 
     await emergencyContactRepository.AddAsync(contact, cancellationToken);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      patient,
+      "emergency_contact.created",
+      "emergency_contact",
+      contact.Id,
+      201,
+      cancellationToken: cancellationToken);
     return Map(contact);
   }
 
@@ -80,6 +101,13 @@ internal sealed class EmergencyContactService(
 
     emergencyContactRepository.Update(contact);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      patient,
+      "emergency_contact.updated",
+      "emergency_contact",
+      contact.Id,
+      200,
+      cancellationToken: cancellationToken);
     return Map(contact);
   }
 
@@ -96,6 +124,13 @@ internal sealed class EmergencyContactService(
 
     emergencyContactRepository.Delete(contact);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      patient,
+      "emergency_contact.deleted",
+      "emergency_contact",
+      contact.Id,
+      200,
+      cancellationToken: cancellationToken);
     return true;
   }
 

--- a/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Configuration;
 using Aarogya.Api.Security;
@@ -20,7 +21,7 @@ internal sealed class ReportService(
   IUserRepository userRepository,
   IAccessGrantRepository accessGrantRepository,
   IReportRepository reportRepository,
-  IAuditLogRepository auditLogRepository,
+  IAuditLoggingService auditLoggingService,
   IPatientNotificationService patientNotificationService,
   IUnitOfWork unitOfWork,
   IOptions<AwsOptions> awsOptions,
@@ -107,6 +108,20 @@ internal sealed class ReportService(
         report.CreatedAt))
       .ToArray();
 
+    await auditLoggingService.LogDataAccessAsync(
+      user,
+      "report.listed",
+      "report",
+      null,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["totalCount"] = totalCount.ToString(CultureInfo.InvariantCulture),
+        ["page"] = page.ToString(CultureInfo.InvariantCulture),
+        ["pageSize"] = pageSize.ToString(CultureInfo.InvariantCulture)
+      },
+      cancellationToken);
+
     return new ReportListResponse(page, pageSize, totalCount, items);
   }
 
@@ -135,7 +150,17 @@ internal sealed class ReportService(
     }
 
     var download = await CreateSignedDownloadUrlAsync(report.FileStorageKey, null, cancellationToken);
-    await WriteReportAccessAuditLogAsync(user, report, cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      user,
+      "report.viewed",
+      "report",
+      report.Id,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["reportType"] = ToReportTypeCode(report.ReportType)
+      },
+      cancellationToken);
 
     report.Metadata.Tags.TryGetValue("lab-name", out var labName);
     report.Metadata.Tags.TryGetValue("lab-code", out var labCode);
@@ -213,6 +238,18 @@ internal sealed class ReportService(
 
     await reportRepository.AddAsync(report, cancellationToken);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      uploader,
+      "report.created",
+      "report",
+      report.Id,
+      201,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["reportType"] = ToReportTypeCode(report.ReportType),
+        ["patientUserId"] = report.PatientId.ToString("D")
+      },
+      cancellationToken);
 
     if (uploader.Role == UserRole.LabTechnician)
     {
@@ -376,37 +413,6 @@ internal sealed class ReportService(
 
     var s3Url = await s3Client.GetPreSignedURLAsync(presignRequest);
     return new ReportSignedDownloadUrlResponse(objectKey, new Uri(s3Url, UriKind.Absolute), expiresAt, "s3");
-  }
-
-  private async Task WriteReportAccessAuditLogAsync(
-    User actor,
-    Report report,
-    CancellationToken cancellationToken)
-  {
-    var auditLog = new AuditLog
-    {
-      Id = Guid.NewGuid(),
-      OccurredAt = clock.UtcNow,
-      ActorUserId = actor.Id,
-      ActorRole = actor.Role,
-      Action = "report.viewed",
-      EntityType = "report",
-      EntityId = report.Id,
-      ResultStatus = 200,
-      Details = new AuditLogDetails
-      {
-        Summary = "Report detail accessed.",
-        Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-          ["reportId"] = report.Id.ToString("D", CultureInfo.InvariantCulture),
-          ["reportNumber"] = report.ReportNumber,
-          ["reportType"] = ToReportTypeCode(report.ReportType)
-        }
-      }
-    };
-
-    await auditLogRepository.AddAsync(auditLog, cancellationToken);
-    await unitOfWork.SaveChangesAsync(cancellationToken);
   }
 
   private async Task<User> ResolvePatientAsync(

--- a/src/Aarogya.Api/Features/V1/Users/UserProfileService.cs
+++ b/src/Aarogya.Api/Features/V1/Users/UserProfileService.cs
@@ -1,3 +1,4 @@
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Security;
 using Aarogya.Domain.Enums;
@@ -10,6 +11,7 @@ internal sealed class UserProfileService(
   IUserRepository userRepository,
   IUnitOfWork unitOfWork,
   IAadhaarVaultService aadhaarVaultService,
+  IAuditLoggingService auditLoggingService,
   IUtcClock clock)
   : IUserProfileService
 {
@@ -19,6 +21,13 @@ internal sealed class UserProfileService(
   {
     var user = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken)
       ?? throw new KeyNotFoundException("Authenticated user is not provisioned in the database.");
+    await auditLoggingService.LogDataAccessAsync(
+      user,
+      "user_profile.read",
+      "user",
+      user.Id,
+      200,
+      cancellationToken: cancellationToken);
 
     return ToResponse(user);
   }
@@ -72,6 +81,13 @@ internal sealed class UserProfileService(
 
     userRepository.Update(user);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      user,
+      "user_profile.updated",
+      "user",
+      user.Id,
+      200,
+      cancellationToken: cancellationToken);
 
     return ToResponse(user);
   }
@@ -100,6 +116,18 @@ internal sealed class UserProfileService(
 
     userRepository.Update(user);
     await unitOfWork.SaveChangesAsync(cancellationToken);
+    await auditLoggingService.LogDataAccessAsync(
+      user,
+      "user_aadhaar.verified",
+      "user",
+      user.Id,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["referenceToken"] = verification.ReferenceToken.ToString("D"),
+        ["provider"] = verification.Provider ?? "unknown"
+      },
+      cancellationToken);
 
     return new AadhaarVerificationResponse(
       verification.ReferenceToken,

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Authorization;
 using Aarogya.Api.Configuration;
@@ -116,6 +117,7 @@ builder.Services.Configure<Microsoft.AspNetCore.Http.Features.FormOptions>(optio
 builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddValidatorsFromAssemblyContaining<OtpRequestCommandValidator>(includeInternalTypes: true);
 builder.Services.AddMemoryCache();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddHttpClient(CognitoOAuthTokenClient.HttpClientName, client =>
 {
@@ -129,6 +131,7 @@ builder.Services.AddSingleton<IPkceAuthorizationService, InMemoryPkceAuthorizati
 builder.Services.AddSingleton<ICognitoSocialTokenClient, CognitoOAuthTokenClient>();
 builder.Services.AddSingleton<ISocialAuthService, InMemorySocialAuthService>();
 builder.Services.AddSingleton<IRoleAssignmentService, InMemoryRoleAssignmentService>();
+builder.Services.AddScoped<IAuditLoggingService, AuditLoggingService>();
 
 // Configure Swagger
 builder.Services.AddSwaggerGen(c =>

--- a/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
@@ -1,3 +1,4 @@
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Configuration;
 using Aarogya.Api.Features.V1.AccessGrants;
@@ -44,6 +45,7 @@ public sealed class AccessGrantServiceTests
       Mock.Of<IReportRepository>(),
       accessGrantRepository.Object,
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       Options.Create(new AccessGrantOptions
       {
         DefaultExpiryDays = 30,
@@ -92,6 +94,7 @@ public sealed class AccessGrantServiceTests
       reportRepository.Object,
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
@@ -130,6 +133,7 @@ public sealed class AccessGrantServiceTests
       Mock.Of<IReportRepository>(),
       accessGrantRepository.Object,
       unitOfWork.Object,
+      Mock.Of<IAuditLoggingService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
@@ -175,6 +179,7 @@ public sealed class AccessGrantServiceTests
       Mock.Of<IReportRepository>(),
       accessGrantRepository.Object,
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(now));
 
@@ -202,6 +207,7 @@ public sealed class AccessGrantServiceTests
       Mock.Of<IReportRepository>(),
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 

--- a/tests/Aarogya.Api.Tests/AuditLoggingServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/AuditLoggingServiceTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using Aarogya.Api.Auditing;
+using Aarogya.Api.Authentication;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class AuditLoggingServiceTests
+{
+  [Fact]
+  public async Task LogDataAccessAsync_ShouldPersistStructuredAuditRecordAsync()
+  {
+    var actor = new User
+    {
+      Id = Guid.NewGuid(),
+      Role = UserRole.Patient
+    };
+    var occurredAt = new DateTimeOffset(2026, 2, 20, 17, 0, 0, TimeSpan.Zero);
+
+    var httpContext = new DefaultHttpContext();
+    httpContext.TraceIdentifier = Guid.NewGuid().ToString("D");
+    httpContext.Connection.RemoteIpAddress = IPAddress.Parse("10.0.0.24");
+    httpContext.Request.Method = HttpMethods.Get;
+    httpContext.Request.Path = "/api/v1/users/me";
+    httpContext.Request.Headers.UserAgent = "UnitTestAgent/1.0";
+    var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+
+    var auditLogRepository = new Mock<IAuditLogRepository>();
+    AuditLog? created = null;
+    auditLogRepository
+      .Setup(x => x.AddAsync(It.IsAny<AuditLog>(), It.IsAny<CancellationToken>()))
+      .Callback<AuditLog, CancellationToken>((auditLog, _) => created = auditLog)
+      .Returns(Task.CompletedTask);
+
+    var unitOfWork = new Mock<IUnitOfWork>();
+    var service = new AuditLoggingService(
+      auditLogRepository.Object,
+      unitOfWork.Object,
+      httpContextAccessor,
+      new FixedUtcClock(occurredAt),
+      NullLogger<AuditLoggingService>.Instance);
+
+    await service.LogDataAccessAsync(
+      actor,
+      "user_profile.read",
+      "user",
+      actor.Id,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["resourceId"] = actor.Id.ToString("D")
+      },
+      CancellationToken.None);
+
+    created.Should().NotBeNull();
+    created!.ActorUserId.Should().Be(actor.Id);
+    created.Action.Should().Be("user_profile.read");
+    created.EntityType.Should().Be("user");
+    created.ClientIp.Should().Be(IPAddress.Parse("10.0.0.24"));
+    created.RequestPath.Should().Be("/api/v1/users/me");
+    created.RequestMethod.Should().Be(HttpMethods.Get);
+    created.Details.Data.Should().ContainKey("occurredAtUtc");
+    created.Details.Data.Should().ContainKey("occurredAtIst");
+    created.Details.Data.Should().ContainKey("resourceId");
+
+    unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  private sealed class FixedUtcClock(DateTimeOffset utcNow) : IUtcClock
+  {
+    public DateTimeOffset UtcNow { get; } = utcNow;
+  }
+}

--- a/tests/Aarogya.Api.Tests/EmergencyContactServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/EmergencyContactServiceTests.cs
@@ -1,3 +1,4 @@
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Features.V1.EmergencyContacts;
 using Aarogya.Domain.Entities;
@@ -42,6 +43,7 @@ public sealed class EmergencyContactServiceTests
       userRepository.Object,
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero)));
 
     var response = await service.AddForUserAsync(
@@ -84,6 +86,7 @@ public sealed class EmergencyContactServiceTests
       userRepository.Object,
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var action = async () => await service.AddForUserAsync(
@@ -127,6 +130,7 @@ public sealed class EmergencyContactServiceTests
       userRepository.Object,
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var updated = await service.UpdateForUserAsync(
@@ -164,6 +168,7 @@ public sealed class EmergencyContactServiceTests
       userRepository.Object,
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var deleted = await service.DeleteForUserAsync("seed-PATIENT-1", Guid.NewGuid(), CancellationToken.None);

--- a/tests/Aarogya.Api.Tests/ReportServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportServiceTests.cs
@@ -1,3 +1,4 @@
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Configuration;
 using Aarogya.Api.Features.V1.Reports;
@@ -57,7 +58,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       Mock.Of<IAccessGrantRepository>(),
       reportRepository.Object,
-      Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IAuditLoggingService>(),
       Mock.Of<IPatientNotificationService>(),
       unitOfWork.Object,
       Options.Create(CreateAwsOptions()),
@@ -102,7 +103,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IReportRepository>(),
-      Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IAuditLoggingService>(),
       Mock.Of<IPatientNotificationService>(),
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),
@@ -169,7 +170,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       Mock.Of<IAccessGrantRepository>(),
       reportRepository.Object,
-      Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IAuditLoggingService>(),
       notificationService.Object,
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),
@@ -261,7 +262,7 @@ public sealed class ReportServiceTests
       .Setup(x => x.GetPreSignedURLAsync(It.IsAny<GetPreSignedUrlRequest>()))
       .ReturnsAsync("https://example.com/signed-download");
 
-    var auditLogRepository = new Mock<IAuditLogRepository>();
+    var auditLoggingService = new Mock<IAuditLoggingService>();
     var unitOfWork = new Mock<IUnitOfWork>();
 
     var service = new ReportService(
@@ -269,7 +270,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       Mock.Of<IAccessGrantRepository>(),
       reportRepository.Object,
-      auditLogRepository.Object,
+      auditLoggingService.Object,
       Mock.Of<IPatientNotificationService>(),
       unitOfWork.Object,
       Options.Create(CreateAwsOptions()),
@@ -282,8 +283,16 @@ public sealed class ReportServiceTests
     response.Download.DownloadUrl.Should().Be(new Uri("https://example.com/signed-download"));
     response.Parameters.Should().HaveCount(1);
 
-    auditLogRepository.Verify(x => x.AddAsync(It.IsAny<AuditLog>(), It.IsAny<CancellationToken>()), Times.Once);
-    unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    auditLoggingService.Verify(
+      x => x.LogDataAccessAsync(
+        It.IsAny<User>(),
+        "report.viewed",
+        "report",
+        report.Id,
+        200,
+        It.IsAny<IReadOnlyDictionary<string, string>>(),
+        It.IsAny<CancellationToken>()),
+      Times.Once);
   }
 
   [Fact]
@@ -332,7 +341,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       accessGrantRepository.Object,
       reportRepository.Object,
-      Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IAuditLoggingService>(),
       Mock.Of<IPatientNotificationService>(),
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),
@@ -403,7 +412,7 @@ public sealed class ReportServiceTests
       userRepository.Object,
       accessGrantRepository.Object,
       reportRepository.Object,
-      Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IAuditLoggingService>(),
       Mock.Of<IPatientNotificationService>(),
       Mock.Of<IUnitOfWork>(),
       Options.Create(CreateAwsOptions()),

--- a/tests/Aarogya.Api.Tests/UserProfileServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/UserProfileServiceTests.cs
@@ -1,3 +1,4 @@
+using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Features.V1.Users;
 using Aarogya.Domain.Entities;
@@ -39,7 +40,7 @@ public sealed class UserProfileServiceTests
 
     var clock = new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 9, 0, 0, TimeSpan.Zero));
 
-    var service = new UserProfileService(repository.Object, unitOfWork.Object, aadhaarVaultService.Object, clock);
+    var service = new UserProfileService(repository.Object, unitOfWork.Object, aadhaarVaultService.Object, Mock.Of<IAuditLoggingService>(), clock);
 
     var response = await service.UpdateCurrentUserAsync(
       "seed-PATIENT-1",
@@ -78,6 +79,7 @@ public sealed class UserProfileServiceTests
       repository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAadhaarVaultService>(),
+      Mock.Of<IAuditLoggingService>(),
       new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 9, 0, 0, TimeSpan.Zero)));
 
     var action = async () => await service.GetCurrentUserAsync("missing-sub", CancellationToken.None);
@@ -114,7 +116,7 @@ public sealed class UserProfileServiceTests
         "request-1"));
 
     var clock = new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 9, 0, 0, TimeSpan.Zero));
-    var service = new UserProfileService(repository.Object, unitOfWork.Object, aadhaarVaultService.Object, clock);
+    var service = new UserProfileService(repository.Object, unitOfWork.Object, aadhaarVaultService.Object, Mock.Of<IAuditLoggingService>(), clock);
 
     var response = await service.VerifyCurrentUserAadhaarAsync(
       "seed-PATIENT-1",
@@ -151,6 +153,7 @@ public sealed class UserProfileServiceTests
       repository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAadhaarVaultService>(),
+      Mock.Of<IAuditLoggingService>(),
       new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 9, 0, 0, TimeSpan.Zero)));
 
     var action = async () => await service.VerifyCurrentUserAadhaarAsync(


### PR DESCRIPTION
## Summary
- add a centralized audit logging service for sensitive data access events
- capture who/what/when/where metadata from user context and HTTP request context
- wire audit logging into user profile, emergency contacts, access grants, and report flows
- add tests for the new audit service and updated service integrations
- document audit logging behavior in README

Closes #52