### PR TITLE
feat: implement data encryption key rotation (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ infra/
 
 scripts/
 ├── install-git-hooks.sh
-└── configure-audit-log-archival.sh # One-time setup script for WS6-3 compliance archival
+├── configure-audit-log-archival.sh # One-time setup script for WS6-3 compliance archival
+└── configure-kms-key-rotation.sh   # One-time setup script for WS6-4 KMS key rotation
 ```
 
 ## ⚙️ Current Service Setup
@@ -220,8 +221,20 @@ Configure encryption via `Encryption` settings:
   "Encryption": {
     "UseAwsKms": true,
     "KmsKeyId": "alias/aarogya-prod-data-key",
+    "ActiveKeyId": "kms-2026",
     "LocalDataKey": "dev-only-local-fallback-key",
+    "LegacyLocalDataKeys": [
+      {
+        "KeyId": "local-2025",
+        "Secret": "legacy-local-secret"
+      }
+    ],
     "BlindIndexKey": "hmac-secret-for-blind-indexes"
+  },
+  "EncryptionRotation": {
+    "EnableBackgroundReEncryption": true,
+    "CheckIntervalMinutes": 1440,
+    "BatchSize": 250
   }
 }
 ```
@@ -229,7 +242,17 @@ Configure encryption via `Encryption` settings:
 Notes:
 - Production: keep `UseAwsKms=true` and set `KmsKeyId`.
 - Local/dev: set `UseAwsKms=false` and provide `LocalDataKey`.
+- Set `ActiveKeyId` to a new value during rotation waves (for example `kms-2027`).
+- Keep previous local keys in `LegacyLocalDataKeys` for backward decryption during migration.
+- A background worker re-encrypts records in batches and writes audit events under `encryption.reencryption.*`.
 - Always set a strong `BlindIndexKey` via user-secrets or environment variables.
+
+KMS annual key-rotation bootstrap:
+```bash
+AWS_REGION=ap-south-1 KMS_ALIAS_NAME=alias/aarogya-prod-data-key ./scripts/configure-kms-key-rotation.sh
+```
+
+Detailed runbook: `docs/infrastructure/encryption-key-rotation.md`
 
 ### Transport Security (TLS)
 Issue #49 adds transport-level TLS enforcement controls for production paths:

--- a/docs/infrastructure/encryption-key-rotation.md
+++ b/docs/infrastructure/encryption-key-rotation.md
@@ -1,0 +1,72 @@
+# Data Encryption Key Rotation
+
+This runbook implements WS6 issue #54 requirements:
+
+- AWS KMS automatic key rotation (annual)
+- Re-encryption strategy without downtime
+- Backward decryption with old keys
+- Audit trail for rotation activity
+
+## Runtime Model
+
+1. Field-level PII encryption uses payload versioning with key metadata.
+2. New writes use `Encryption:ActiveKeyId`.
+3. Reads can decrypt:
+   - current key payloads
+   - legacy payloads via `Encryption:LegacyLocalDataKeys` (local mode)
+   - historical KMS-wrapped keys (KMS mode)
+4. A hosted background worker re-encrypts records in batches and logs audit events:
+   - `encryption.reencryption.started`
+   - `encryption.reencryption.completed`
+   - `encryption.reencryption.failed`
+
+## Configure KMS Automatic Rotation
+
+From repo root:
+
+```bash
+AWS_REGION=ap-south-1 \
+KMS_ALIAS_NAME=alias/aarogya-prod-data-key \
+./scripts/configure-kms-key-rotation.sh
+```
+
+Optional:
+- `AWS_PROFILE`
+- `KMS_KEY_ID` (direct key id/arn)
+- `CREATE_NEW_KEY=true` (if alias does not exist)
+
+## Application Configuration
+
+```json
+{
+  "Encryption": {
+    "UseAwsKms": true,
+    "KmsKeyId": "alias/aarogya-prod-data-key",
+    "ActiveKeyId": "kms-2026",
+    "LegacyLocalDataKeys": []
+  },
+  "EncryptionRotation": {
+    "EnableBackgroundReEncryption": true,
+    "CheckIntervalMinutes": 1440,
+    "BatchSize": 250
+  }
+}
+```
+
+## Rotation Workflow (No Downtime)
+
+1. Update `Encryption:ActiveKeyId` for the new rotation window (example: `kms-2027`).
+2. Deploy application (no outage required).
+3. Background service detects no completion audit for this key id.
+4. Service re-encrypts PII fields in batches while API traffic continues.
+5. Completion audit records touched counts for traceability.
+
+## Local Fallback Rotation
+
+For non-KMS local mode:
+
+- Keep current key in `Encryption:LocalDataKey`
+- Set `Encryption:ActiveKeyId` to a new id
+- Move previous key material into `Encryption:LegacyLocalDataKeys`
+
+This preserves decryption of old payloads while new writes use the active key.

--- a/scripts/configure-kms-key-rotation.sh
+++ b/scripts/configure-kms-key-rotation.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "error: aws CLI is required." >&2
+  exit 1
+fi
+
+AWS_REGION="${AWS_REGION:-ap-south-1}"
+AWS_PROFILE_ARG=()
+if [[ -n "${AWS_PROFILE:-}" ]]; then
+  AWS_PROFILE_ARG=(--profile "${AWS_PROFILE}")
+fi
+
+KMS_KEY_ID="${KMS_KEY_ID:-}"
+KMS_ALIAS_NAME="${KMS_ALIAS_NAME:-alias/aarogya-prod-data-key}"
+CREATE_NEW_KEY="${CREATE_NEW_KEY:-false}"
+
+run_aws() {
+  aws "${AWS_PROFILE_ARG[@]}" --region "${AWS_REGION}" "$@"
+}
+
+resolve_key_id() {
+  if [[ -n "${KMS_KEY_ID}" ]]; then
+    echo "${KMS_KEY_ID}"
+    return
+  fi
+
+  if run_aws kms describe-key --key-id "${KMS_ALIAS_NAME}" >/dev/null 2>&1; then
+    run_aws kms describe-key --key-id "${KMS_ALIAS_NAME}" --query 'KeyMetadata.KeyId' --output text
+    return
+  fi
+
+  if [[ "${CREATE_NEW_KEY}" != "true" ]]; then
+    echo "error: could not resolve key '${KMS_ALIAS_NAME}'. Set KMS_KEY_ID or CREATE_NEW_KEY=true." >&2
+    exit 1
+  fi
+
+  local new_key_id
+  new_key_id="$(run_aws kms create-key \
+    --description "Aarogya field encryption key" \
+    --query 'KeyMetadata.KeyId' \
+    --output text)"
+
+  run_aws kms create-alias --alias-name "${KMS_ALIAS_NAME}" --target-key-id "${new_key_id}"
+  echo "${new_key_id}"
+}
+
+KEY_ID="$(resolve_key_id)"
+echo "Using key: ${KEY_ID}"
+
+echo "Enabling automatic key rotation..."
+run_aws kms enable-key-rotation --key-id "${KEY_ID}"
+
+STATUS="$(run_aws kms get-key-rotation-status --key-id "${KEY_ID}" --query KeyRotationEnabled --output text)"
+echo "Key rotation enabled: ${STATUS}"
+if [[ "${STATUS}" != "True" ]]; then
+  echo "error: key rotation is not enabled." >&2
+  exit 1
+fi
+
+echo "KMS key rotation setup complete."
+echo "Set application configuration:"
+echo "  Encryption:UseAwsKms=true"
+echo "  Encryption:KmsKeyId=${KMS_ALIAS_NAME}"
+echo "  Encryption:ActiveKeyId=kms-$(date +%Y)"

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -8,8 +8,10 @@ using Aarogya.Api.Endpoints;
 using Aarogya.Api.Features.V1;
 using Aarogya.Api.Health;
 using Aarogya.Api.RateLimiting;
+using Aarogya.Api.Security;
 using Aarogya.Api.Validation;
 using Aarogya.Infrastructure;
+using Aarogya.Infrastructure.Security;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -89,6 +91,11 @@ builder.Services
   .BindConfiguration(RateLimitingOptions.SectionName)
   .ValidateDataAnnotations();
 
+builder.Services
+  .AddOptionsWithValidateOnStart<DataEncryptionRotationOptions>()
+  .BindConfiguration(DataEncryptionRotationOptions.SectionName)
+  .ValidateDataAnnotations();
+
 // Add Infrastructure services (DbContext, health checks, etc.)
 builder.Services.AddInfrastructure(builder.Configuration);
 
@@ -132,6 +139,7 @@ builder.Services.AddSingleton<ICognitoSocialTokenClient, CognitoOAuthTokenClient
 builder.Services.AddSingleton<ISocialAuthService, InMemorySocialAuthService>();
 builder.Services.AddSingleton<IRoleAssignmentService, InMemoryRoleAssignmentService>();
 builder.Services.AddScoped<IAuditLoggingService, AuditLoggingService>();
+builder.Services.AddHostedService<DataEncryptionKeyRotationHostedService>();
 
 // Configure Swagger
 builder.Services.AddSwaggerGen(c =>

--- a/src/Aarogya.Api/Security/DataEncryptionKeyRotationHostedService.cs
+++ b/src/Aarogya.Api/Security/DataEncryptionKeyRotationHostedService.cs
@@ -1,0 +1,152 @@
+using Aarogya.Api.Authentication;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.ValueObjects;
+using Aarogya.Infrastructure.Persistence;
+using Aarogya.Infrastructure.Security;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Security;
+
+internal sealed class DataEncryptionKeyRotationHostedService(
+  IServiceScopeFactory scopeFactory,
+  IOptions<DataEncryptionRotationOptions> rotationOptions,
+  ILogger<DataEncryptionKeyRotationHostedService> logger)
+  : BackgroundService
+{
+  private readonly DataEncryptionRotationOptions _rotationOptions = rotationOptions.Value;
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    if (!_rotationOptions.EnableBackgroundReEncryption)
+    {
+      logger.LogInformation("Background data re-encryption is disabled.");
+      return;
+    }
+
+    await RunRotationCycleAsync(stoppingToken);
+
+    using var timer = new PeriodicTimer(TimeSpan.FromMinutes(_rotationOptions.CheckIntervalMinutes));
+    while (!stoppingToken.IsCancellationRequested
+      && await timer.WaitForNextTickAsync(stoppingToken))
+    {
+      await RunRotationCycleAsync(stoppingToken);
+    }
+  }
+
+  private async Task RunRotationCycleAsync(CancellationToken cancellationToken)
+  {
+    await using var scope = scopeFactory.CreateAsyncScope();
+    var dbContext = scope.ServiceProvider.GetRequiredService<AarogyaDbContext>();
+    var utcClock = scope.ServiceProvider.GetRequiredService<IUtcClock>();
+    var encryptionService = scope.ServiceProvider.GetRequiredService<IPiiFieldEncryptionService>();
+    var rotationService = scope.ServiceProvider.GetRequiredService<IDataEncryptionKeyRotationService>();
+
+    var activeKeyId = encryptionService.ActiveKeyId;
+    if (await HasCompletedRotationForKeyAsync(dbContext, activeKeyId, cancellationToken))
+    {
+      logger.LogDebug("Data re-encryption already completed for key {ActiveKeyId}; skipping cycle.", activeKeyId);
+      return;
+    }
+
+    logger.LogInformation("Starting data re-encryption cycle for key {ActiveKeyId}", activeKeyId);
+    await WriteSystemRotationAuditAsync(
+      dbContext,
+      utcClock.UtcNow,
+      "encryption.reencryption.started",
+      $"Data re-encryption started for key '{activeKeyId}'.",
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["keyId"] = activeKeyId
+      },
+      200,
+      cancellationToken);
+
+    try
+    {
+      var summary = await rotationService.ReEncryptAllAsync(cancellationToken);
+      await WriteSystemRotationAuditAsync(
+        dbContext,
+        utcClock.UtcNow,
+        "encryption.reencryption.completed",
+        $"Data re-encryption completed for key '{summary.ActiveKeyId}'.",
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["keyId"] = summary.ActiveKeyId,
+          ["usersTouched"] = summary.UsersTouched.ToString(System.Globalization.CultureInfo.InvariantCulture),
+          ["emergencyContactsTouched"] = summary.EmergencyContactsTouched.ToString(System.Globalization.CultureInfo.InvariantCulture),
+          ["aadhaarRecordsTouched"] = summary.AadhaarRecordsTouched.ToString(System.Globalization.CultureInfo.InvariantCulture),
+          ["totalTouched"] = summary.TotalTouched.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        },
+        200,
+        cancellationToken);
+
+      logger.LogInformation(
+        "Data re-encryption completed for key {ActiveKeyId}. Users={Users}, EmergencyContacts={Contacts}, AadhaarRecords={Aadhaar}.",
+        summary.ActiveKeyId,
+        summary.UsersTouched,
+        summary.EmergencyContactsTouched,
+        summary.AadhaarRecordsTouched);
+    }
+    catch (Exception ex)
+    {
+      await WriteSystemRotationAuditAsync(
+        dbContext,
+        utcClock.UtcNow,
+        "encryption.reencryption.failed",
+        $"Data re-encryption failed for key '{activeKeyId}'.",
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["keyId"] = activeKeyId,
+          ["errorType"] = ex.GetType().Name
+        },
+        500,
+        cancellationToken);
+
+      logger.LogError(ex, "Data re-encryption failed for key {ActiveKeyId}", activeKeyId);
+    }
+  }
+
+  private static async Task<bool> HasCompletedRotationForKeyAsync(
+    AarogyaDbContext dbContext,
+    string activeKeyId,
+    CancellationToken cancellationToken)
+  {
+    var recentCompletions = await dbContext.AuditLogs
+      .AsNoTracking()
+      .Where(x => x.Action == "encryption.reencryption.completed")
+      .OrderByDescending(x => x.OccurredAt)
+      .Take(25)
+      .ToListAsync(cancellationToken);
+
+    return recentCompletions.Exists(
+      x => x.Details.Data.TryGetValue("keyId", out var keyId)
+        && string.Equals(keyId, activeKeyId, StringComparison.Ordinal));
+  }
+
+  private static async Task WriteSystemRotationAuditAsync(
+    AarogyaDbContext dbContext,
+    DateTimeOffset occurredAt,
+    string action,
+    string summary,
+    Dictionary<string, string> metadata,
+    int resultStatus,
+    CancellationToken cancellationToken)
+  {
+    dbContext.AuditLogs.Add(new AuditLog
+    {
+      Id = Guid.NewGuid(),
+      OccurredAt = occurredAt,
+      Action = action,
+      EntityType = "encryption_key",
+      ResultStatus = resultStatus,
+      Details = new AuditLogDetails
+      {
+        Summary = summary,
+        Data = metadata
+      }
+    });
+
+    await dbContext.SaveChangesAsync(cancellationToken);
+  }
+}

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -66,8 +66,15 @@
   "Encryption": {
     "UseAwsKms": false,
     "KmsKeyId": "alias/aarogya-dev-data-key",
+    "ActiveKeyId": "local-dev-v1",
     "LocalDataKey": "aarogya-local-dev-encryption-key",
+    "LegacyLocalDataKeys": [],
     "BlindIndexKey": "aarogya-local-dev-blind-index-key"
+  },
+  "EncryptionRotation": {
+    "EnableBackgroundReEncryption": true,
+    "CheckIntervalMinutes": 60,
+    "BatchSize": 250
   },
   "AadhaarVault": {
     "UseMockApi": true,

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -113,8 +113,15 @@
   "Encryption": {
     "UseAwsKms": true,
     "KmsKeyId": "SET_VIA_USER_SECRETS_OR_ENV_VAR",
+    "ActiveKeyId": "kms-primary",
     "LocalDataKey": "SET_VIA_USER_SECRETS_OR_ENV_VAR",
+    "LegacyLocalDataKeys": [],
     "BlindIndexKey": "SET_VIA_USER_SECRETS_OR_ENV_VAR"
+  },
+  "EncryptionRotation": {
+    "EnableBackgroundReEncryption": true,
+    "CheckIntervalMinutes": 1440,
+    "BatchSize": 250
   },
   "AadhaarVault": {
     "UseMockApi": true,

--- a/src/Aarogya.Api/secrets.template.json
+++ b/src/Aarogya.Api/secrets.template.json
@@ -20,8 +20,14 @@
   "Aws:Cognito:SocialIdentityProviders:Google:ClientId": "your-google-client-id",
   "Aws:Cognito:SocialIdentityProviders:Google:ClientSecret": "your-google-client-secret",
   "Encryption:KmsKeyId": "your-kms-key-id-or-arn",
+  "Encryption:ActiveKeyId": "kms-primary",
   "Encryption:LocalDataKey": "local-fallback-key-for-dev-only",
+  "Encryption:LegacyLocalDataKeys:0:KeyId": "local-2025",
+  "Encryption:LegacyLocalDataKeys:0:Secret": "legacy-local-key-material",
   "Encryption:BlindIndexKey": "blind-index-hmac-secret",
+  "EncryptionRotation:EnableBackgroundReEncryption": "true",
+  "EncryptionRotation:CheckIntervalMinutes": "1440",
+  "EncryptionRotation:BatchSize": "250",
   "AadhaarVault:MockApiBaseUrl": "http://localhost:5099",
 
   "Redis:Password": ""

--- a/src/Aarogya.Infrastructure/DependencyInjection.cs
+++ b/src/Aarogya.Infrastructure/DependencyInjection.cs
@@ -106,8 +106,12 @@ public static class DependencyInjection
     var encryptionOptions = new EncryptionOptions();
     configuration.GetSection(EncryptionOptions.SectionName).Bind(encryptionOptions);
     services.AddSingleton(Options.Create(encryptionOptions));
+    var encryptionRotationOptions = new DataEncryptionRotationOptions();
+    configuration.GetSection(DataEncryptionRotationOptions.SectionName).Bind(encryptionRotationOptions);
+    services.AddSingleton(Options.Create(encryptionRotationOptions));
     services.AddSingleton<IPiiFieldEncryptionService, PiiFieldEncryptionService>();
     services.AddSingleton<IBlindIndexService, BlindIndexService>();
+    services.AddScoped<IDataEncryptionKeyRotationService, DataEncryptionKeyRotationService>();
 
     if (!string.IsNullOrWhiteSpace(redisConnectionString))
     {

--- a/src/Aarogya.Infrastructure/Security/DataEncryptionKeyRotationService.cs
+++ b/src/Aarogya.Infrastructure/Security/DataEncryptionKeyRotationService.cs
@@ -1,0 +1,145 @@
+using Aarogya.Domain.Entities;
+using Aarogya.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Infrastructure.Security;
+
+public sealed class DataEncryptionKeyRotationService(
+  AarogyaDbContext dbContext,
+  IPiiFieldEncryptionService encryptionService,
+  IOptions<DataEncryptionRotationOptions> rotationOptions)
+  : IDataEncryptionKeyRotationService
+{
+  private readonly DataEncryptionRotationOptions _rotationOptions = rotationOptions.Value;
+
+  public async Task<DataEncryptionReEncryptionSummary> ReEncryptAllAsync(CancellationToken cancellationToken = default)
+  {
+    var batchSize = _rotationOptions.BatchSize;
+    var usersTouched = await ReEncryptUsersAsync(batchSize, cancellationToken);
+    var emergencyContactsTouched = await ReEncryptEmergencyContactsAsync(batchSize, cancellationToken);
+    var aadhaarRecordsTouched = await ReEncryptAadhaarRecordsAsync(batchSize, cancellationToken);
+
+    return new DataEncryptionReEncryptionSummary(
+      encryptionService.ActiveKeyId,
+      usersTouched,
+      emergencyContactsTouched,
+      aadhaarRecordsTouched);
+  }
+
+  private async Task<int> ReEncryptUsersAsync(int batchSize, CancellationToken cancellationToken)
+  {
+    Guid? cursor = null;
+    var touched = 0;
+
+    while (true)
+    {
+      var batch = await dbContext.Users
+        .OrderBy(x => x.Id)
+        .Where(x => !cursor.HasValue || x.Id.CompareTo(cursor.Value) > 0)
+        .Take(batchSize)
+        .ToListAsync(cancellationToken);
+
+      if (batch.Count == 0)
+      {
+        return touched;
+      }
+
+      foreach (var user in batch)
+      {
+        MarkUserEncryptedFieldsModified(user);
+      }
+
+      await dbContext.SaveChangesAsync(cancellationToken);
+      touched += batch.Count;
+      cursor = batch[^1].Id;
+      dbContext.ChangeTracker.Clear();
+    }
+  }
+
+  private async Task<int> ReEncryptEmergencyContactsAsync(int batchSize, CancellationToken cancellationToken)
+  {
+    Guid? cursor = null;
+    var touched = 0;
+
+    while (true)
+    {
+      var batch = await dbContext.EmergencyContacts
+        .OrderBy(x => x.Id)
+        .Where(x => !cursor.HasValue || x.Id.CompareTo(cursor.Value) > 0)
+        .Take(batchSize)
+        .ToListAsync(cancellationToken);
+
+      if (batch.Count == 0)
+      {
+        return touched;
+      }
+
+      foreach (var contact in batch)
+      {
+        MarkEmergencyContactEncryptedFieldsModified(contact);
+      }
+
+      await dbContext.SaveChangesAsync(cancellationToken);
+      touched += batch.Count;
+      cursor = batch[^1].Id;
+      dbContext.ChangeTracker.Clear();
+    }
+  }
+
+  private async Task<int> ReEncryptAadhaarRecordsAsync(int batchSize, CancellationToken cancellationToken)
+  {
+    Guid? cursor = null;
+    var touched = 0;
+
+    while (true)
+    {
+      var batch = await dbContext.AadhaarVaultRecords
+        .OrderBy(x => x.Id)
+        .Where(x => !cursor.HasValue || x.Id.CompareTo(cursor.Value) > 0)
+        .Take(batchSize)
+        .ToListAsync(cancellationToken);
+
+      if (batch.Count == 0)
+      {
+        return touched;
+      }
+
+      foreach (var record in batch)
+      {
+        MarkAadhaarRecordEncryptedFieldsModified(record);
+      }
+
+      await dbContext.SaveChangesAsync(cancellationToken);
+      touched += batch.Count;
+      cursor = batch[^1].Id;
+      dbContext.ChangeTracker.Clear();
+    }
+  }
+
+  private void MarkUserEncryptedFieldsModified(User user)
+  {
+    var entry = dbContext.Entry(user);
+    entry.Property(x => x.FirstName).IsModified = true;
+    entry.Property(x => x.LastName).IsModified = true;
+    entry.Property(x => x.Email).IsModified = true;
+    entry.Property(x => x.Phone).IsModified = true;
+    entry.Property(x => x.Address).IsModified = true;
+    entry.Property(x => x.BloodGroup).IsModified = true;
+  }
+
+  private void MarkEmergencyContactEncryptedFieldsModified(EmergencyContact contact)
+  {
+    var entry = dbContext.Entry(contact);
+    entry.Property(x => x.Name).IsModified = true;
+    entry.Property(x => x.Phone).IsModified = true;
+    entry.Property(x => x.Email).IsModified = true;
+  }
+
+  private void MarkAadhaarRecordEncryptedFieldsModified(AadhaarVaultRecord record)
+  {
+    var entry = dbContext.Entry(record);
+    entry.Property(x => x.AadhaarNumber).IsModified = true;
+    entry.Property(x => x.DemographicsJson).IsModified = true;
+  }
+}

--- a/src/Aarogya.Infrastructure/Security/DataEncryptionRotationOptions.cs
+++ b/src/Aarogya.Infrastructure/Security/DataEncryptionRotationOptions.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Aarogya.Infrastructure.Security;
+
+public sealed class DataEncryptionRotationOptions
+{
+  public const string SectionName = "EncryptionRotation";
+
+  public bool EnableBackgroundReEncryption { get; set; } = true;
+
+  [Range(10, 10_080)]
+  public int CheckIntervalMinutes { get; set; } = 1_440;
+
+  [Range(50, 5_000)]
+  public int BatchSize { get; set; } = 250;
+}

--- a/src/Aarogya.Infrastructure/Security/EncryptionOptions.cs
+++ b/src/Aarogya.Infrastructure/Security/EncryptionOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Aarogya.Infrastructure.Security;
@@ -22,8 +23,27 @@ public sealed class EncryptionOptions
   public string? LocalDataKey { get; set; }
 
   /// <summary>
+  /// Logical key identifier stamped into encrypted payloads.
+  /// </summary>
+  public string ActiveKeyId { get; set; } = "local-primary";
+
+  /// <summary>
+  /// Legacy local keys kept for backward decryption during/after rotation.
+  /// </summary>
+  public Collection<LegacyEncryptionKeyOptions> LegacyLocalDataKeys { get; set; } = [];
+
+  /// <summary>
   /// Secret material used to derive blind-index HMAC key.
   /// </summary>
   [Required]
   public string BlindIndexKey { get; set; } = "SET_VIA_USER_SECRETS_OR_ENV_VAR";
+}
+
+public sealed class LegacyEncryptionKeyOptions
+{
+  [Required]
+  public string KeyId { get; set; } = string.Empty;
+
+  [Required]
+  public string Secret { get; set; } = string.Empty;
 }

--- a/src/Aarogya.Infrastructure/Security/IDataEncryptionKeyRotationService.cs
+++ b/src/Aarogya.Infrastructure/Security/IDataEncryptionKeyRotationService.cs
@@ -1,0 +1,15 @@
+namespace Aarogya.Infrastructure.Security;
+
+public interface IDataEncryptionKeyRotationService
+{
+  public Task<DataEncryptionReEncryptionSummary> ReEncryptAllAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record DataEncryptionReEncryptionSummary(
+  string ActiveKeyId,
+  int UsersTouched,
+  int EmergencyContactsTouched,
+  int AadhaarRecordsTouched)
+{
+  public int TotalTouched => UsersTouched + EmergencyContactsTouched + AadhaarRecordsTouched;
+}

--- a/src/Aarogya.Infrastructure/Security/IPiiFieldEncryptionService.cs
+++ b/src/Aarogya.Infrastructure/Security/IPiiFieldEncryptionService.cs
@@ -2,7 +2,11 @@ namespace Aarogya.Infrastructure.Security;
 
 public interface IPiiFieldEncryptionService
 {
+  public string ActiveKeyId { get; }
+
   public byte[]? Encrypt(string? plaintext);
 
   public string? Decrypt(byte[]? ciphertext);
+
+  public string? GetEncryptionKeyId(byte[]? ciphertext);
 }

--- a/src/Aarogya.Infrastructure/Security/PiiFieldEncryptionService.cs
+++ b/src/Aarogya.Infrastructure/Security/PiiFieldEncryptionService.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.Text;
 using Amazon.KeyManagementService;
@@ -10,11 +11,12 @@ public sealed class PiiFieldEncryptionService : IPiiFieldEncryptionService
 {
   private const int NonceLength = 12;
   private const int TagLength = 16;
-  private const byte PayloadVersion = 1;
+  private const byte LegacyPayloadVersion = 1;
+  private const byte PayloadVersion = 2;
 
   private readonly EncryptionOptions _options;
   private readonly IAmazonKeyManagementService? _kmsClient;
-  private readonly Lazy<byte[]> _dataKey;
+  private readonly LocalKeyRing _localKeyRing;
 
   public PiiFieldEncryptionService(
     IOptions<EncryptionOptions> options,
@@ -24,8 +26,11 @@ public sealed class PiiFieldEncryptionService : IPiiFieldEncryptionService
 
     _options = options.Value;
     _kmsClient = kmsClient;
-    _dataKey = new Lazy<byte[]>(ResolveDataKey, isThreadSafe: true);
+    _localKeyRing = BuildLocalKeyRing(_options);
+    ActiveKeyId = ResolveActiveKeyId(_options);
   }
+
+  public string ActiveKeyId { get; }
 
   public byte[]? Encrypt(string? plaintext)
   {
@@ -35,22 +40,9 @@ public sealed class PiiFieldEncryptionService : IPiiFieldEncryptionService
     }
 
     var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
-    var nonce = RandomNumberGenerator.GetBytes(NonceLength);
-    var ciphertext = new byte[plaintextBytes.Length];
-    var tag = new byte[TagLength];
-
-    using (var aes = new AesGcm(_dataKey.Value, TagLength))
-    {
-      aes.Encrypt(nonce, plaintextBytes, ciphertext, tag);
-    }
-
-    var payload = new byte[1 + NonceLength + TagLength + ciphertext.Length];
-    payload[0] = PayloadVersion;
-    Buffer.BlockCopy(nonce, 0, payload, 1, NonceLength);
-    Buffer.BlockCopy(tag, 0, payload, 1 + NonceLength, TagLength);
-    Buffer.BlockCopy(ciphertext, 0, payload, 1 + NonceLength + TagLength, ciphertext.Length);
-
-    return payload;
+    return _options.UseAwsKms
+      ? EncryptWithKmsEnvelope(plaintextBytes)
+      : EncryptWithLocalKey(plaintextBytes, ActiveKeyId);
   }
 
   public string? Decrypt(byte[]? ciphertext)
@@ -65,59 +57,329 @@ public sealed class PiiFieldEncryptionService : IPiiFieldEncryptionService
       throw new CryptographicException("Invalid encrypted payload.");
     }
 
-    if (ciphertext[0] != PayloadVersion)
+    var version = ciphertext[0];
+    return version switch
     {
-      throw new CryptographicException($"Unsupported encrypted payload version '{ciphertext[0]}'.");
+      PayloadVersion => DecryptV2(ciphertext),
+      LegacyPayloadVersion => DecryptLegacyV1(ciphertext),
+      _ => throw new CryptographicException($"Unsupported encrypted payload version '{version}'.")
+    };
+  }
+
+  public string? GetEncryptionKeyId(byte[]? ciphertext)
+  {
+    if (ciphertext is null || ciphertext.Length == 0)
+    {
+      return null;
     }
 
+    if (ciphertext[0] == LegacyPayloadVersion)
+    {
+      return "legacy-v1";
+    }
+
+    if (ciphertext[0] != PayloadVersion)
+    {
+      return null;
+    }
+
+    TryParseV2Payload(ciphertext, out var keyId, out _, out _, out _, out _);
+    return keyId;
+  }
+
+  private byte[] EncryptWithLocalKey(ReadOnlySpan<byte> plaintextBytes, string keyId)
+  {
+    var keyMaterial = ResolveLocalKeyById(keyId);
+    var nonce = RandomNumberGenerator.GetBytes(NonceLength);
+    var tag = new byte[TagLength];
+    var encryptedData = new byte[plaintextBytes.Length];
+
+    using (var aes = new AesGcm(keyMaterial, TagLength))
+    {
+      aes.Encrypt(nonce, plaintextBytes, encryptedData, tag);
+    }
+
+    return BuildV2Payload(keyId, wrappedKey: null, nonce, tag, encryptedData);
+  }
+
+  private byte[] EncryptWithKmsEnvelope(ReadOnlySpan<byte> plaintextBytes)
+  {
+    if (_kmsClient is null)
+    {
+      throw new InvalidOperationException("AWS KMS is enabled but IAmazonKeyManagementService is not registered.");
+    }
+
+    if (string.IsNullOrWhiteSpace(_options.KmsKeyId))
+    {
+      throw new InvalidOperationException("Encryption:KmsKeyId must be configured when AWS KMS is enabled.");
+    }
+
+    var request = new GenerateDataKeyRequest
+    {
+      KeyId = _options.KmsKeyId,
+      KeySpec = DataKeySpec.AES_256
+    };
+
+    var response = _kmsClient.GenerateDataKeyAsync(request).GetAwaiter().GetResult();
+    if (response.Plaintext is null || response.CiphertextBlob is null)
+    {
+      throw new InvalidOperationException("AWS KMS did not return a usable data key.");
+    }
+
+    var dataKey = response.Plaintext.ToArray();
+    var wrappedKey = response.CiphertextBlob.ToArray();
+    var nonce = RandomNumberGenerator.GetBytes(NonceLength);
+    var tag = new byte[TagLength];
+    var encryptedData = new byte[plaintextBytes.Length];
+
+    try
+    {
+      using (var aes = new AesGcm(dataKey, TagLength))
+      {
+        aes.Encrypt(nonce, plaintextBytes, encryptedData, tag);
+      }
+    }
+    finally
+    {
+      CryptographicOperations.ZeroMemory(dataKey);
+    }
+
+    return BuildV2Payload(ActiveKeyId, wrappedKey, nonce, tag, encryptedData);
+  }
+
+  private string DecryptV2(byte[] ciphertext)
+  {
+    TryParseV2Payload(ciphertext, out var keyId, out var wrappedKey, out var nonce, out var tag, out var encryptedData);
+
+    var keyMaterial = wrappedKey.Length > 0
+      ? DecryptKmsWrappedDataKey(wrappedKey)
+      : ResolveLocalKeyById(keyId);
+
+    var plaintextBytes = new byte[encryptedData.Length];
+    try
+    {
+      using (var aes = new AesGcm(keyMaterial, TagLength))
+      {
+        aes.Decrypt(nonce, encryptedData, tag, plaintextBytes);
+      }
+    }
+    finally
+    {
+      if (wrappedKey.Length > 0)
+      {
+        CryptographicOperations.ZeroMemory(keyMaterial);
+      }
+    }
+
+    return Encoding.UTF8.GetString(plaintextBytes);
+  }
+
+  private string DecryptLegacyV1(byte[] ciphertext)
+  {
     var nonce = ciphertext.AsSpan(1, NonceLength).ToArray();
     var tag = ciphertext.AsSpan(1 + NonceLength, TagLength).ToArray();
     var encryptedData = ciphertext.AsSpan(1 + NonceLength + TagLength).ToArray();
-    var plaintext = new byte[encryptedData.Length];
 
-    using (var aes = new AesGcm(_dataKey.Value, TagLength))
+    foreach (var candidateKey in _localKeyRing.V1FallbackKeys)
     {
-      aes.Decrypt(nonce, encryptedData, tag, plaintext);
+      if (TryDecryptLegacyV1(candidateKey, nonce, tag, encryptedData, out var plaintext))
+      {
+        return plaintext;
+      }
     }
 
-    return Encoding.UTF8.GetString(plaintext);
-  }
-
-  private byte[] ResolveDataKey()
-  {
     if (_options.UseAwsKms)
     {
-      if (_kmsClient is null)
-      {
-        throw new InvalidOperationException("AWS KMS is enabled but IAmazonKeyManagementService is not registered.");
-      }
-
-      if (string.IsNullOrWhiteSpace(_options.KmsKeyId))
-      {
-        throw new InvalidOperationException("Encryption:KmsKeyId must be configured when AWS KMS is enabled.");
-      }
-
-      var request = new GenerateDataKeyRequest
-      {
-        KeyId = _options.KmsKeyId,
-        KeySpec = DataKeySpec.AES_256
-      };
-
-      var response = _kmsClient.GenerateDataKeyAsync(request).GetAwaiter().GetResult();
-      if (response.Plaintext is null)
-      {
-        throw new InvalidOperationException("AWS KMS did not return plaintext data key material.");
-      }
-
-      return response.Plaintext.ToArray();
+      throw new CryptographicException("Legacy payload version 1 cannot be decrypted in AWS KMS mode.");
     }
 
-    if (!string.IsNullOrWhiteSpace(_options.LocalDataKey)
-      && _options.LocalDataKey != "SET_VIA_USER_SECRETS_OR_ENV_VAR")
+    throw new CryptographicException("Failed to decrypt legacy payload with configured local key ring.");
+  }
+
+  private static bool TryDecryptLegacyV1(byte[] key, byte[] nonce, byte[] tag, byte[] encryptedData, out string plaintext)
+  {
+    var plaintextBytes = new byte[encryptedData.Length];
+    try
     {
-      return SHA256.HashData(Encoding.UTF8.GetBytes(_options.LocalDataKey));
+      using (var aes = new AesGcm(key, TagLength))
+      {
+        aes.Decrypt(nonce, encryptedData, tag, plaintextBytes);
+      }
+
+      plaintext = Encoding.UTF8.GetString(plaintextBytes);
+      return true;
+    }
+    catch (CryptographicException)
+    {
+      plaintext = string.Empty;
+      return false;
+    }
+  }
+
+  private byte[] DecryptKmsWrappedDataKey(byte[] wrappedKey)
+  {
+    if (_kmsClient is null)
+    {
+      throw new InvalidOperationException("AWS KMS is enabled but IAmazonKeyManagementService is not registered.");
     }
 
-    return SHA256.HashData(Encoding.UTF8.GetBytes("aarogya-dev-local-data-key"));
+    var request = new DecryptRequest
+    {
+      CiphertextBlob = new MemoryStream(wrappedKey)
+    };
+
+    var response = _kmsClient.DecryptAsync(request).GetAwaiter().GetResult();
+    if (response.Plaintext is null)
+    {
+      throw new InvalidOperationException("AWS KMS did not return plaintext key material.");
+    }
+
+    return response.Plaintext.ToArray();
+  }
+
+  private byte[] ResolveLocalKeyById(string keyId)
+  {
+    if (!_localKeyRing.Keys.TryGetValue(keyId, out var material))
+    {
+      throw new CryptographicException($"Encryption key '{keyId}' is not configured.");
+    }
+
+    return material;
+  }
+
+  private static void TryParseV2Payload(
+    byte[] payload,
+    out string keyId,
+    out byte[] wrappedKey,
+    out byte[] nonce,
+    out byte[] tag,
+    out byte[] encryptedData)
+  {
+    if (payload.Length < 1 + 2 + 2 + NonceLength + TagLength)
+    {
+      throw new CryptographicException("Invalid encrypted payload.");
+    }
+
+    var cursor = 1;
+    var keyIdLength = BinaryPrimitives.ReadUInt16BigEndian(payload.AsSpan(cursor, 2));
+    cursor += 2;
+    if (keyIdLength == 0 || cursor + keyIdLength > payload.Length)
+    {
+      throw new CryptographicException("Invalid encrypted payload key id.");
+    }
+
+    keyId = Encoding.UTF8.GetString(payload, cursor, keyIdLength);
+    cursor += keyIdLength;
+
+    if (cursor + 2 > payload.Length)
+    {
+      throw new CryptographicException("Invalid encrypted payload wrapped key header.");
+    }
+
+    var wrappedKeyLength = BinaryPrimitives.ReadUInt16BigEndian(payload.AsSpan(cursor, 2));
+    cursor += 2;
+    if (cursor + wrappedKeyLength + NonceLength + TagLength > payload.Length)
+    {
+      throw new CryptographicException("Invalid encrypted payload wrapped key.");
+    }
+
+    wrappedKey = payload.AsSpan(cursor, wrappedKeyLength).ToArray();
+    cursor += wrappedKeyLength;
+    nonce = payload.AsSpan(cursor, NonceLength).ToArray();
+    cursor += NonceLength;
+    tag = payload.AsSpan(cursor, TagLength).ToArray();
+    cursor += TagLength;
+    encryptedData = payload.AsSpan(cursor).ToArray();
+  }
+
+  private static byte[] BuildV2Payload(string keyId, byte[]? wrappedKey, byte[] nonce, byte[] tag, byte[] encryptedData)
+  {
+    var keyIdBytes = Encoding.UTF8.GetBytes(keyId);
+    if (keyIdBytes.Length > ushort.MaxValue)
+    {
+      throw new CryptographicException("Encryption key id is too long.");
+    }
+
+    wrappedKey ??= [];
+    if (wrappedKey.Length > ushort.MaxValue)
+    {
+      throw new CryptographicException("Wrapped key length exceeds payload limits.");
+    }
+
+    var payload = new byte[1 + 2 + keyIdBytes.Length + 2 + wrappedKey.Length + NonceLength + TagLength + encryptedData.Length];
+    payload[0] = PayloadVersion;
+
+    var cursor = 1;
+    BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(cursor, 2), (ushort)keyIdBytes.Length);
+    cursor += 2;
+    keyIdBytes.CopyTo(payload.AsSpan(cursor, keyIdBytes.Length));
+    cursor += keyIdBytes.Length;
+    BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(cursor, 2), (ushort)wrappedKey.Length);
+    cursor += 2;
+    wrappedKey.CopyTo(payload.AsSpan(cursor, wrappedKey.Length));
+    cursor += wrappedKey.Length;
+    nonce.CopyTo(payload.AsSpan(cursor, NonceLength));
+    cursor += NonceLength;
+    tag.CopyTo(payload.AsSpan(cursor, TagLength));
+    cursor += TagLength;
+    encryptedData.CopyTo(payload.AsSpan(cursor, encryptedData.Length));
+
+    return payload;
+  }
+
+  private static LocalKeyRing BuildLocalKeyRing(EncryptionOptions options)
+  {
+    var keys = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+    var v1Fallback = new List<byte[]>();
+    var activeKeyId = ResolveActiveKeyId(options);
+
+    var activeSecret = ResolveLocalSecret(options.LocalDataKey);
+    var activeMaterial = SHA256.HashData(Encoding.UTF8.GetBytes(activeSecret));
+    keys[activeKeyId] = activeMaterial;
+    v1Fallback.Add(activeMaterial);
+
+    foreach (var legacy in options.LegacyLocalDataKeys)
+    {
+      if (string.IsNullOrWhiteSpace(legacy.KeyId) || string.IsNullOrWhiteSpace(legacy.Secret))
+      {
+        continue;
+      }
+
+      var material = SHA256.HashData(Encoding.UTF8.GetBytes(legacy.Secret));
+      keys[legacy.KeyId] = material;
+      v1Fallback.Add(material);
+    }
+
+    return new LocalKeyRing(keys, v1Fallback.ToArray());
+  }
+
+  private static string ResolveLocalSecret(string? configuredKey)
+  {
+    if (!string.IsNullOrWhiteSpace(configuredKey)
+      && configuredKey != "SET_VIA_USER_SECRETS_OR_ENV_VAR")
+    {
+      return configuredKey;
+    }
+
+    return "aarogya-dev-local-data-key";
+  }
+
+  private static string ResolveActiveKeyId(EncryptionOptions options)
+  {
+    if (!string.IsNullOrWhiteSpace(options.ActiveKeyId))
+    {
+      return options.ActiveKeyId;
+    }
+
+    return options.UseAwsKms
+      ? options.KmsKeyId ?? "kms-primary"
+      : "local-primary";
+  }
+
+  private sealed class LocalKeyRing(Dictionary<string, byte[]> keys, byte[][] v1FallbackKeys)
+  {
+    public Dictionary<string, byte[]> Keys { get; } = keys;
+
+    public byte[][] V1FallbackKeys { get; } = v1FallbackKeys;
   }
 }

--- a/tests/Aarogya.Infrastructure.Tests/PiiFieldEncryptionServiceTests.cs
+++ b/tests/Aarogya.Infrastructure.Tests/PiiFieldEncryptionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Aarogya.Infrastructure.Security;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
@@ -38,12 +39,46 @@ public sealed class PiiFieldEncryptionServiceTests
     service.Decrypt(null).Should().BeNull();
   }
 
-  private static PiiFieldEncryptionService CreateService()
+  [Fact]
+  public void Encrypt_ShouldStampActiveKeyId()
+  {
+    var service = CreateService();
+
+    var encrypted = service.Encrypt("alice@example.com");
+
+    service.GetEncryptionKeyId(encrypted).Should().Be("local-current");
+  }
+
+  [Fact]
+  public void Decrypt_ShouldSupportLegacyLocalKeyRing()
+  {
+    var legacyService = CreateService("legacy-local-key", "local-legacy");
+    var encryptedWithLegacy = legacyService.Encrypt("alice@example.com");
+
+    var service = CreateService(
+      activeLocalKey: "current-local-key",
+      activeKeyId: "local-current",
+      legacy: new Collection<LegacyEncryptionKeyOptions>
+      {
+        new() { KeyId = "local-legacy", Secret = "legacy-local-key" }
+      });
+
+    var decrypted = service.Decrypt(encryptedWithLegacy);
+
+    decrypted.Should().Be("alice@example.com");
+  }
+
+  private static PiiFieldEncryptionService CreateService(
+    string activeLocalKey = "test-local-data-key",
+    string activeKeyId = "local-current",
+    Collection<LegacyEncryptionKeyOptions>? legacy = null)
   {
     var options = Options.Create(new EncryptionOptions
     {
       UseAwsKms = false,
-      LocalDataKey = "test-local-data-key",
+      ActiveKeyId = activeKeyId,
+      LocalDataKey = activeLocalKey,
+      LegacyLocalDataKeys = legacy ?? [],
       BlindIndexKey = "blind-index-key"
     });
 


### PR DESCRIPTION
## Summary
- upgrade PII encryption payload format to include active key identity for rotation-safe decryption
- add local legacy key-ring support for backward decryption during cutovers
- add background batch re-encryption service (no downtime) with audit log entries
- add KMS key-rotation bootstrap script and runbook documentation
- update encryption/rotation configuration in appsettings and README

Closes #54