### PR TITLE
test: add unit coverage for domain and security logic

### DIFF
--- a/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
@@ -219,6 +219,172 @@ public sealed class AccessGrantServiceTests
     await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Cannot grant access to self*");
   }
 
+  [Fact]
+  public async Task CreateAsync_ShouldRejectExpiryBeyondConfiguredLimitAsync()
+  {
+    var now = new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero);
+    var patient = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-PATIENT-1", Role = UserRole.Patient };
+    var doctor = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-DOCTOR-1", Role = UserRole.Doctor };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(patient);
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-DOCTOR-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(doctor);
+
+    var service = new AccessGrantService(
+      userRepository.Object,
+      Mock.Of<IReportRepository>(),
+      Mock.Of<IAccessGrantRepository>(),
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
+      Options.Create(new AccessGrantOptions
+      {
+        DefaultExpiryDays = 30,
+        MaxExpiryDays = 180
+      }),
+      new FixedUtcClock(now));
+
+    var action = async () => await service.CreateAsync(
+      "seed-PATIENT-1",
+      new CreateAccessGrantRequest(
+        "seed-DOCTOR-1",
+        true,
+        null,
+        "care-plan",
+        now.AddDays(181)),
+      CancellationToken.None);
+
+    await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*cannot exceed*");
+  }
+
+  [Fact]
+  public async Task GetForPatientAsync_ShouldReturnOnlyActiveWindowedGrantsAsync()
+  {
+    var now = new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero);
+    var patient = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-PATIENT-1", Role = UserRole.Patient };
+    var doctor = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-DOCTOR-1", Role = UserRole.Doctor };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(patient);
+
+    var grants = new List<AccessGrant>
+    {
+      new()
+      {
+        Id = Guid.NewGuid(),
+        Patient = patient,
+        GrantedToUser = doctor,
+        PatientId = patient.Id,
+        GrantedToUserId = doctor.Id,
+        Scope = new Domain.ValueObjects.AccessGrantScope(),
+        GrantReason = "active",
+        Status = AccessGrantStatus.Active,
+        StartsAt = now.AddDays(-1),
+        ExpiresAt = now.AddDays(2)
+      },
+      new()
+      {
+        Id = Guid.NewGuid(),
+        Patient = patient,
+        GrantedToUser = doctor,
+        PatientId = patient.Id,
+        GrantedToUserId = doctor.Id,
+        Scope = new Domain.ValueObjects.AccessGrantScope(),
+        GrantReason = "expired",
+        Status = AccessGrantStatus.Active,
+        StartsAt = now.AddDays(-5),
+        ExpiresAt = now.AddSeconds(-1)
+      },
+      new()
+      {
+        Id = Guid.NewGuid(),
+        Patient = patient,
+        GrantedToUser = doctor,
+        PatientId = patient.Id,
+        GrantedToUserId = doctor.Id,
+        Scope = new Domain.ValueObjects.AccessGrantScope(),
+        GrantReason = "future",
+        Status = AccessGrantStatus.Active,
+        StartsAt = now.AddMinutes(1),
+        ExpiresAt = now.AddDays(3)
+      },
+      new()
+      {
+        Id = Guid.NewGuid(),
+        Patient = patient,
+        GrantedToUser = doctor,
+        PatientId = patient.Id,
+        GrantedToUserId = doctor.Id,
+        Scope = new Domain.ValueObjects.AccessGrantScope(),
+        GrantReason = "revoked",
+        Status = AccessGrantStatus.Revoked,
+        StartsAt = now.AddDays(-1),
+        ExpiresAt = now.AddDays(3)
+      }
+    };
+
+    var accessGrantRepository = new Mock<IAccessGrantRepository>();
+    accessGrantRepository
+      .Setup(x => x.ListAsync(It.IsAny<ISpecification<AccessGrant>>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(grants);
+
+    var service = new AccessGrantService(
+      userRepository.Object,
+      Mock.Of<IReportRepository>(),
+      accessGrantRepository.Object,
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
+      Options.Create(new AccessGrantOptions()),
+      new FixedUtcClock(now));
+
+    var result = await service.GetForPatientAsync("seed-PATIENT-1", CancellationToken.None);
+
+    result.Should().HaveCount(1);
+    result[0].Purpose.Should().Be("active");
+  }
+
+  [Fact]
+  public async Task RevokeAsync_ShouldReturnFalse_WhenGrantIsNotActiveAsync()
+  {
+    var patient = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-PATIENT-1", Role = UserRole.Patient };
+    var grant = new AccessGrant
+    {
+      Id = Guid.NewGuid(),
+      PatientId = patient.Id,
+      Status = AccessGrantStatus.Revoked
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(patient);
+
+    var accessGrantRepository = new Mock<IAccessGrantRepository>();
+    accessGrantRepository
+      .Setup(x => x.FirstOrDefaultAsync(It.IsAny<ISpecification<AccessGrant>>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(grant);
+
+    var unitOfWork = new Mock<IUnitOfWork>();
+    var service = new AccessGrantService(
+      userRepository.Object,
+      Mock.Of<IReportRepository>(),
+      accessGrantRepository.Object,
+      unitOfWork.Object,
+      Mock.Of<IAuditLoggingService>(),
+      Options.Create(new AccessGrantOptions()),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var revoked = await service.RevokeAsync("seed-PATIENT-1", grant.Id, CancellationToken.None);
+
+    revoked.Should().BeFalse();
+    unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
   private sealed class FixedUtcClock(DateTimeOffset utcNow) : IUtcClock
   {
     public DateTimeOffset UtcNow { get; } = utcNow;

--- a/tests/Aarogya.Api.Tests/ConsentServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/ConsentServiceTests.cs
@@ -131,6 +131,94 @@ public sealed class ConsentServiceTests
     result.Should().Contain(x => x.Purpose == ConsentPurposeCatalog.MedicalRecordsProcessing && !x.IsGranted);
   }
 
+  [Fact]
+  public async Task UpsertForUserAsync_ShouldDefaultSourceToApi_WhenSourceIsBlankAsync()
+  {
+    var user = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-user-1" };
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync(user.ExternalAuthId!, It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
+
+    ConsentRecord? created = null;
+    var consentRepository = new Mock<IConsentRecordRepository>();
+    consentRepository
+      .Setup(x => x.AddAsync(It.IsAny<ConsentRecord>(), It.IsAny<CancellationToken>()))
+      .Callback<ConsentRecord, CancellationToken>((record, _) => created = record)
+      .Returns(Task.CompletedTask);
+
+    var service = new ConsentService(
+      userRepository.Object,
+      consentRepository.Object,
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var result = await service.UpsertForUserAsync(
+      user.ExternalAuthId!,
+      ConsentPurposeCatalog.MedicalDataSharing,
+      new UpsertConsentRequest(true, "   "),
+      CancellationToken.None);
+
+    result.Source.Should().Be("api");
+    created.Should().NotBeNull();
+    created!.Source.Should().Be("api");
+  }
+
+  [Fact]
+  public async Task EnsureGrantedAsync_ShouldNotThrow_WhenConsentExistsAsync()
+  {
+    var user = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-user-1" };
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync(user.ExternalAuthId!, It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
+
+    var consentRepository = new Mock<IConsentRecordRepository>();
+    consentRepository
+      .Setup(x => x.IsGrantedAsync(user.Id, ConsentPurposeCatalog.ProfileManagement, It.IsAny<CancellationToken>()))
+      .ReturnsAsync(true);
+
+    var service = new ConsentService(
+      userRepository.Object,
+      consentRepository.Object,
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var action = async () => await service.EnsureGrantedAsync(
+      user.ExternalAuthId!,
+      ConsentPurposeCatalog.ProfileManagement,
+      CancellationToken.None);
+
+    await action.Should().NotThrowAsync();
+  }
+
+  [Fact]
+  public async Task EnsureGrantedAsync_ShouldRejectUnsupportedPurposeAsync()
+  {
+    var user = new User { Id = Guid.NewGuid(), ExternalAuthId = "seed-user-1" };
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync(user.ExternalAuthId!, It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
+
+    var service = new ConsentService(
+      userRepository.Object,
+      Mock.Of<IConsentRecordRepository>(),
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var action = async () => await service.EnsureGrantedAsync(
+      user.ExternalAuthId!,
+      "unsupported-purpose",
+      CancellationToken.None);
+
+    await action.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*Unsupported consent purpose*");
+  }
+
   private sealed class FixedUtcClock(DateTimeOffset utcNow) : IUtcClock
   {
     public DateTimeOffset UtcNow { get; } = utcNow;

--- a/tests/Aarogya.Api.Tests/EmergencyContactServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/EmergencyContactServiceTests.cs
@@ -176,6 +176,81 @@ public sealed class EmergencyContactServiceTests
     deleted.Should().BeFalse();
   }
 
+  [Fact]
+  public async Task AddForUserAsync_ShouldRejectNonPatientUserAsync()
+  {
+    var doctor = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = "seed-DOCTOR-1",
+      Role = UserRole.Doctor
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-DOCTOR-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(doctor);
+
+    var service = new EmergencyContactService(
+      userRepository.Object,
+      Mock.Of<IEmergencyContactRepository>(),
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var action = async () => await service.AddForUserAsync(
+      "seed-DOCTOR-1",
+      new CreateEmergencyContactRequest("Kin One", "+919876543210", "brother"),
+      CancellationToken.None);
+
+    await action.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*Only patient users can manage emergency contacts*");
+  }
+
+  [Fact]
+  public async Task DeleteForUserAsync_ShouldDeleteContact_WhenFoundAsync()
+  {
+    var patient = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = "seed-PATIENT-1",
+      Role = UserRole.Patient
+    };
+
+    var contact = new EmergencyContact
+    {
+      Id = Guid.NewGuid(),
+      UserId = patient.Id,
+      Name = "Kin One",
+      Phone = "+919876543210",
+      Relationship = "brother"
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(patient);
+
+    var emergencyContactRepository = new Mock<IEmergencyContactRepository>();
+    emergencyContactRepository
+      .Setup(x => x.FirstOrDefaultAsync(It.IsAny<ISpecification<EmergencyContact>>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(contact);
+
+    var unitOfWork = new Mock<IUnitOfWork>();
+    var service = new EmergencyContactService(
+      userRepository.Object,
+      emergencyContactRepository.Object,
+      unitOfWork.Object,
+      Mock.Of<IAuditLoggingService>(),
+      new FixedUtcClock(DateTimeOffset.UtcNow));
+
+    var deleted = await service.DeleteForUserAsync("seed-PATIENT-1", contact.Id, CancellationToken.None);
+
+    deleted.Should().BeTrue();
+    emergencyContactRepository.Verify(x => x.Delete(contact), Times.Once);
+    unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+  }
+
   private sealed class FixedUtcClock(DateTimeOffset utcNow) : IUtcClock
   {
     public DateTimeOffset UtcNow { get; } = utcNow;

--- a/tests/Aarogya.Domain.Tests/AccessGrantSpecificationsTests.cs
+++ b/tests/Aarogya.Domain.Tests/AccessGrantSpecificationsTests.cs
@@ -1,0 +1,100 @@
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Specifications;
+using Aarogya.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Aarogya.Domain.Tests;
+
+public sealed class AccessGrantSpecificationsTests
+{
+  [Fact]
+  public void ActiveAccessGrantSpecification_ShouldMatchOnlyActiveWindowedGrantAsync()
+  {
+    var now = new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero);
+    var patientId = Guid.NewGuid();
+    var doctorId = Guid.NewGuid();
+
+    var specification = new ActiveAccessGrantSpecification(patientId, doctorId, now);
+    var predicate = specification.Criteria!.Compile();
+
+    var active = CreateGrant(patientId, doctorId, AccessGrantStatus.Active, now.AddMinutes(-1), now.AddDays(1));
+    var expired = CreateGrant(patientId, doctorId, AccessGrantStatus.Active, now.AddDays(-1), now.AddSeconds(-1));
+    var future = CreateGrant(patientId, doctorId, AccessGrantStatus.Active, now.AddMinutes(1), now.AddDays(1));
+    var revoked = CreateGrant(patientId, doctorId, AccessGrantStatus.Revoked, now.AddDays(-1), now.AddDays(1));
+
+    predicate(active).Should().BeTrue();
+    predicate(expired).Should().BeFalse();
+    predicate(future).Should().BeFalse();
+    predicate(revoked).Should().BeFalse();
+  }
+
+  [Fact]
+  public void ActiveAccessGrantsForDoctorSpecification_ShouldRequireReadScopeAsync()
+  {
+    var now = new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero);
+    var doctorId = Guid.NewGuid();
+
+    var specification = new ActiveAccessGrantsForDoctorSpecification(doctorId, now);
+    var predicate = specification.Criteria!.Compile();
+
+    var readable = CreateGrant(Guid.NewGuid(), doctorId, AccessGrantStatus.Active, now.AddDays(-1), now.AddDays(1));
+    readable.Scope = new AccessGrantScope
+    {
+      CanReadReports = true,
+      CanDownloadReports = true
+    };
+
+    var notReadable = CreateGrant(Guid.NewGuid(), doctorId, AccessGrantStatus.Active, now.AddDays(-1), now.AddDays(1));
+    notReadable.Scope = new AccessGrantScope
+    {
+      CanReadReports = false,
+      CanDownloadReports = true
+    };
+
+    predicate(readable).Should().BeTrue();
+    predicate(notReadable).Should().BeFalse();
+  }
+
+  [Fact]
+  public void EmergencyContactByIdForUserSpecification_ShouldMatchExactOwnerAndContactAsync()
+  {
+    var userId = Guid.NewGuid();
+    var contactId = Guid.NewGuid();
+    var specification = new EmergencyContactByIdForUserSpecification(userId, contactId);
+    var predicate = specification.Criteria!.Compile();
+
+    var ownedContact = new EmergencyContact { Id = contactId, UserId = userId };
+    var otherContact = new EmergencyContact { Id = Guid.NewGuid(), UserId = userId };
+    var otherUserContact = new EmergencyContact { Id = contactId, UserId = Guid.NewGuid() };
+
+    predicate(ownedContact).Should().BeTrue();
+    predicate(otherContact).Should().BeFalse();
+    predicate(otherUserContact).Should().BeFalse();
+  }
+
+  private static AccessGrant CreateGrant(
+    Guid patientId,
+    Guid doctorId,
+    AccessGrantStatus status,
+    DateTimeOffset startsAt,
+    DateTimeOffset? expiresAt)
+  {
+    return new AccessGrant
+    {
+      Id = Guid.NewGuid(),
+      PatientId = patientId,
+      GrantedToUserId = doctorId,
+      GrantedByUserId = patientId,
+      Status = status,
+      StartsAt = startsAt,
+      ExpiresAt = expiresAt,
+      Scope = new AccessGrantScope
+      {
+        CanReadReports = true,
+        CanDownloadReports = true
+      }
+    };
+  }
+}

--- a/tests/Aarogya.Infrastructure.Tests/PiiFieldEncryptionServiceTests.cs
+++ b/tests/Aarogya.Infrastructure.Tests/PiiFieldEncryptionServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Security.Cryptography;
 using Aarogya.Infrastructure.Security;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
@@ -66,6 +67,31 @@ public sealed class PiiFieldEncryptionServiceTests
     var decrypted = service.Decrypt(encryptedWithLegacy);
 
     decrypted.Should().Be("alice@example.com");
+  }
+
+  [Fact]
+  public void Decrypt_ShouldThrow_WhenPayloadIsTampered()
+  {
+    var service = CreateService();
+    var ciphertext = service.Encrypt("alice@example.com")!;
+    ciphertext[^1] ^= 0xFF;
+
+    var action = () => service.Decrypt(ciphertext);
+
+    action.Should().Throw<CryptographicException>();
+  }
+
+  [Fact]
+  public void Decrypt_ShouldThrow_WhenPayloadVersionIsUnsupported()
+  {
+    var service = CreateService();
+    var unsupportedPayload = new byte[29];
+    unsupportedPayload[0] = 99;
+
+    var action = () => service.Decrypt(unsupportedPayload);
+
+    action.Should().Throw<CryptographicException>()
+      .WithMessage("*Unsupported encrypted payload version*");
   }
 
   private static PiiFieldEncryptionService CreateService(


### PR DESCRIPTION
## Summary
- add domain specification tests for access-grant and emergency-contact criteria behavior
- expand access-grant service tests for expiry bounds, active-window filtering, and revoked grant behavior
- expand consent service tests for default source handling, granted path, and unsupported purpose rejection
- expand emergency contact tests for non-patient restriction and successful delete path
- add encryption edge-case tests for tampered payload and unsupported payload version handling

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #59
