### PR TITLE
feat: add core API integration tests (#60)

### DIFF
--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Aarogya.Api.Auditing;
@@ -267,4 +268,16 @@ catch (Exception ex)
 finally
 {
   await Log.CloseAndFlushAsync();
+}
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Public for WebApplicationFactory-based integration tests.")]
+[SuppressMessage(
+  "Major Code Smell",
+  "S1118",
+  Justification = "Top-level statements generate the entry point; this partial declaration enables test hosting.")]
+public partial class Program
+{
 }

--- a/tests/Aarogya.Api.Tests/Aarogya.Api.Tests.csproj
+++ b/tests/Aarogya.Api.Tests/Aarogya.Api.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Aarogya.Api.Tests/CoreApiIntegrationTests.cs
+++ b/tests/Aarogya.Api.Tests/CoreApiIntegrationTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Aarogya.Api.Tests.Fixtures;
+using FluentAssertions;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class CoreApiIntegrationTests(ApiPostgreSqlWebApplicationFactory factory) : IClassFixture<ApiPostgreSqlWebApplicationFactory>
+{
+  [Fact]
+  public async Task ProtectedEndpoint_ShouldReturnUnauthorized_WhenTokenMissingAsync()
+  {
+    using var client = factory.CreateClient();
+
+    var response = await client.GetAsync(Relative("/api/v1/users/me"));
+
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Theory]
+  [InlineData("invalid-token")]
+  [InlineData("expired-token")]
+  public async Task ProtectedEndpoint_ShouldReturnUnauthorized_WhenTokenInvalidOrExpiredAsync(string token)
+  {
+    using var client = factory.CreateClient();
+    SetBearer(client, token);
+
+    var response = await client.GetAsync(Relative("/api/v1/users/me"));
+
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+  }
+
+  [Fact]
+  public async Task UsersMe_ShouldRequireConsent_ThenReturnProfileAsync()
+  {
+    using var client = factory.CreateClient();
+    SetBearer(client, "valid-patient");
+
+    await factory.GrantConsentAsync("seed-PATIENT-IT", "profile_management");
+
+    var success = await client.GetAsync(Relative("/api/v1/users/me"));
+    success.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    using var payload = JsonDocument.Parse(await success.Content.ReadAsStringAsync());
+    payload.RootElement.GetProperty("sub").GetString().Should().Be("seed-PATIENT-IT");
+  }
+
+  [Fact]
+  public async Task EmergencyContacts_ShouldEnforceRbac_ForDoctorAsync()
+  {
+    using var client = factory.CreateClient();
+    SetBearer(client, "valid-doctor");
+
+    var response = await client.GetAsync(Relative("/api/v1/emergency-contacts"));
+
+    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+  }
+
+  [Fact]
+  public async Task EmergencyContactCrud_ShouldWork_ForPatientWithConsentAsync()
+  {
+    using var client = factory.CreateClient();
+    SetBearer(client, "valid-patient");
+
+    await factory.GrantConsentAsync("seed-PATIENT-IT", "emergency_contact_management");
+
+    var createResponse = await client.PostAsJsonAsync(
+      Relative("/api/v1/emergency-contacts"),
+      new
+      {
+        name = "Kin One",
+        phoneNumber = "+919876543210",
+        relationship = "brother",
+        email = "kin.one@integration.dev"
+      });
+    createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+    using var createdPayload = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
+    var contactId = createdPayload.RootElement.GetProperty("contactId").GetGuid();
+
+    var listResponse = await client.GetAsync(Relative("/api/v1/emergency-contacts"));
+    listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    using var listedPayload = JsonDocument.Parse(await listResponse.Content.ReadAsStringAsync());
+    listedPayload.RootElement.EnumerateArray().Any(x => x.GetProperty("contactId").GetGuid() == contactId).Should().BeTrue();
+
+    var deleteResponse = await client.DeleteAsync(Relative($"/api/v1/emergency-contacts/{contactId}"));
+    deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+  }
+
+  [Fact]
+  public async Task AccessGrantFlow_ShouldAllowPatientCreateAndDoctorReadReceivedAsync()
+  {
+    using var patientClient = factory.CreateClient();
+    SetBearer(patientClient, "valid-patient");
+
+    await factory.GrantConsentAsync("seed-PATIENT-IT", "medical_data_sharing");
+
+    var createGrantResponse = await patientClient.PostAsJsonAsync(
+      Relative("/api/v1/access-grants"),
+      new
+      {
+        doctorSub = "seed-DOCTOR-IT",
+        allReports = true,
+        reportIds = Array.Empty<Guid>(),
+        purpose = "integration-care",
+        expiresAt = DateTimeOffset.UtcNow.AddDays(10)
+      });
+    createGrantResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+    using var doctorClient = factory.CreateClient();
+    SetBearer(doctorClient, "valid-doctor");
+
+    await factory.GrantConsentAsync("seed-DOCTOR-IT", "medical_data_sharing");
+
+    var receivedResponse = await doctorClient.GetAsync(Relative("/api/v1/access-grants/received"));
+    receivedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    using var receivedPayload = JsonDocument.Parse(await receivedResponse.Content.ReadAsStringAsync());
+    receivedPayload.RootElement.EnumerateArray().Any(x => x.GetProperty("doctorSub").GetString() == "seed-DOCTOR-IT").Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task AccessGrantEndpoint_ShouldRejectDoctorForPatientOnlyRouteAsync()
+  {
+    using var client = factory.CreateClient();
+    SetBearer(client, "valid-doctor");
+
+    var response = await client.GetAsync(Relative("/api/v1/access-grants"));
+
+    response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+  }
+
+  [Fact]
+  public async Task ReportUploadFlow_ShouldCreateReport_WhenConsentGrantedAsync()
+  {
+    using var client = factory.CreateClient();
+    SetBearer(client, "valid-patient");
+
+    await factory.GrantConsentAsync("seed-PATIENT-IT", "medical_records_processing");
+
+    using var form = new MultipartFormDataContent();
+    var fileContent = new ByteArrayContent([0x25, 0x50, 0x44, 0x46, 0x2D]);
+    fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+    form.Add(fileContent, "file", "report.pdf");
+
+    var uploadResponse = await client.PostAsync(Relative("/api/v1/reports/upload"), form);
+
+    uploadResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    using var payload = JsonDocument.Parse(await uploadResponse.Content.ReadAsStringAsync());
+    payload.RootElement.GetProperty("reportId").GetGuid().Should().NotBe(Guid.Empty);
+    payload.RootElement.GetProperty("objectKey").GetString().Should().NotBeNullOrWhiteSpace();
+  }
+
+  private static void SetBearer(HttpClient client, string token)
+  {
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+  }
+
+  private static Uri Relative(string path)
+  {
+    return new Uri(path, UriKind.Relative);
+  }
+}

--- a/tests/Aarogya.Api.Tests/Fixtures/ApiPostgreSqlWebApplicationFactory.cs
+++ b/tests/Aarogya.Api.Tests/Fixtures/ApiPostgreSqlWebApplicationFactory.cs
@@ -1,0 +1,388 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Aarogya.Api.Auditing;
+using Aarogya.Api.Features.V1.Reports;
+using Aarogya.Domain.Entities;
+using Aarogya.Infrastructure.Persistence;
+using Aarogya.Infrastructure.Security;
+using Aarogya.Infrastructure.Seeding;
+using Amazon.CloudFront;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.SQS;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Npgsql;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Fixtures;
+
+public sealed class ApiPostgreSqlWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+  private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+    .WithImage("postgres:16-alpine")
+    .WithDatabase("postgres")
+    .WithUsername("postgres")
+    .WithPassword("postgres")
+    .Build();
+
+  private string _connectionString = string.Empty;
+
+  public async Task InitializeAsync()
+  {
+    await _container.StartAsync();
+    _connectionString = await CreateIsolatedDatabaseConnectionStringAsync(CancellationToken.None);
+    _ = CreateClient();
+    await SeedUsersAsync();
+  }
+
+  [SuppressMessage(
+    "Style",
+    "IDE0002:Name can be simplified",
+    Justification = "Explicit base dispose call is intentional for WebApplicationFactory cleanup.")]
+  public new async Task DisposeAsync()
+  {
+    base.Dispose();
+    await _container.DisposeAsync();
+  }
+
+  protected override void ConfigureWebHost(IWebHostBuilder builder)
+  {
+    builder.UseEnvironment("Development");
+    builder.UseSetting("ConnectionStrings:DefaultConnection", _connectionString);
+    builder.UseDefaultServiceProvider((_, options) =>
+    {
+      options.ValidateOnBuild = false;
+      options.ValidateScopes = false;
+    });
+
+    builder.ConfigureAppConfiguration((_, configBuilder) =>
+    {
+      configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+      {
+        ["ConnectionStrings:DefaultConnection"] = _connectionString,
+        ["Database:AutoMigrateOnStartup"] = "true",
+        ["SeedData:EnableOnStartup"] = "false",
+        ["Aws:UseLocalStack"] = "true",
+        ["Aws:ServiceUrl"] = "http://localhost:4566",
+        ["Aws:S3:BucketName"] = "aarogya-dev",
+        ["Aws:Sqs:QueueName"] = "aarogya-dev-queue",
+        ["Aws:Sqs:ConfigureS3NotificationsOnStartup"] = "false",
+        ["Aws:Sqs:EnableUploadEventConsumer"] = "false",
+        ["VirusScanning:EnableScanning"] = "false",
+        ["FileDeletion:EnableHardDeleteWorker"] = "false",
+        ["EncryptionRotation:EnableBackgroundReEncryption"] = "false",
+        ["Encryption:UseAwsKms"] = "false",
+        ["Encryption:LocalDataKey"] = "integration-tests-local-key",
+        ["Encryption:BlindIndexKey"] = "integration-tests-blind-index-key"
+      });
+    });
+
+    builder.ConfigureServices(services =>
+    {
+      services.RemoveAll<IAmazonS3>();
+      services.RemoveAll<IAmazonSQS>();
+      services.RemoveAll<IAmazonCloudFront>();
+      services.RemoveAll<IDataSeeder>();
+      services.RemoveAll<IAuditLoggingService>();
+      services.RemoveAll<IReportFileUploadService>();
+      services.RemoveAll<IHostedService>();
+
+      var s3 = new Mock<IAmazonS3>();
+      s3.Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new PutObjectResponse());
+      s3.Setup(x => x.GetPreSignedURLAsync(It.IsAny<GetPreSignedUrlRequest>()))
+        .ReturnsAsync("https://example.com/signed-url");
+
+      services.AddSingleton(s3.Object);
+      services.AddSingleton(Mock.Of<IAmazonSQS>());
+      services.AddSingleton(Mock.Of<IAmazonCloudFront>());
+      services.AddSingleton<IDataSeeder, NoOpDataSeeder>();
+      services.AddSingleton<IAuditLoggingService, NoOpAuditLoggingService>();
+      services.AddSingleton<IReportFileUploadService, NoOpReportFileUploadService>();
+
+      services.AddAuthentication(options =>
+      {
+        options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+        options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+      }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+    });
+  }
+
+  private async Task SeedUsersAsync()
+  {
+    await using var scope = Services.CreateAsyncScope();
+    var dbContext = scope.ServiceProvider.GetRequiredService<AarogyaDbContext>();
+    var encryptionService = scope.ServiceProvider.GetRequiredService<IPiiFieldEncryptionService>();
+
+    if (await dbContext.Users.AnyAsync(x => x.ExternalAuthId == "seed-PATIENT-IT"))
+    {
+      return;
+    }
+
+    var now = DateTimeOffset.UtcNow;
+    await InsertSeedUserAsync(
+      dbContext,
+      encryptionService,
+      "seed-PATIENT-IT",
+      "patient",
+      "Seed",
+      "Patient",
+      "seed.patient.integration@aarogya.dev",
+      "+919876543210",
+      now);
+    await InsertSeedUserAsync(
+      dbContext,
+      encryptionService,
+      "seed-DOCTOR-IT",
+      "doctor",
+      "Seed",
+      "Doctor",
+      "seed.doctor.integration@aarogya.dev",
+      "+919876543211",
+      now);
+    await InsertSeedUserAsync(
+      dbContext,
+      encryptionService,
+      "seed-LAB-IT",
+      "lab_technician",
+      "Seed",
+      "Lab",
+      "seed.lab.integration@aarogya.dev",
+      "+919876543212",
+      now);
+  }
+
+  public async Task GrantConsentAsync(string userSub, string purpose, string source = "integration-tests")
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(userSub);
+    ArgumentException.ThrowIfNullOrWhiteSpace(purpose);
+
+    await using var scope = Services.CreateAsyncScope();
+    var dbContext = scope.ServiceProvider.GetRequiredService<AarogyaDbContext>();
+    var now = DateTimeOffset.UtcNow;
+
+    _ = await dbContext.Database.ExecuteSqlRawAsync(
+      """
+      INSERT INTO consent_records
+      (
+        id,
+        user_id,
+        purpose,
+        is_granted,
+        source,
+        occurred_at,
+        created_at,
+        updated_at
+      )
+      SELECT
+        {0},
+        u.id,
+        {1},
+        TRUE,
+        {2},
+        {3},
+        {3},
+        {3}
+      FROM users u
+      WHERE u.external_auth_id = {4};
+      """,
+      Guid.NewGuid(),
+      purpose,
+      source,
+      now,
+      userSub);
+  }
+
+  private static async Task InsertSeedUserAsync(
+    AarogyaDbContext dbContext,
+    IPiiFieldEncryptionService encryptionService,
+    string externalAuthId,
+    string role,
+    string firstName,
+    string lastName,
+    string email,
+    string phone,
+    DateTimeOffset now)
+  {
+    _ = await dbContext.Database.ExecuteSqlRawAsync(
+      """
+      INSERT INTO users
+      (
+        id,
+        external_auth_id,
+        role,
+        first_name_encrypted,
+        last_name_encrypted,
+        email_encrypted,
+        phone_encrypted,
+        is_active,
+        created_at,
+        updated_at
+      )
+      VALUES
+      (
+        {0},
+        {1},
+        CAST({2} AS user_role),
+        {3},
+        {4},
+        {5},
+        {6},
+        TRUE,
+        {7},
+        {7}
+      )
+      ON CONFLICT (external_auth_id) DO NOTHING;
+      """,
+      Guid.NewGuid(),
+      externalAuthId,
+      role,
+      encryptionService.Encrypt(firstName)!,
+      encryptionService.Encrypt(lastName)!,
+      encryptionService.Encrypt(email)!,
+      encryptionService.Encrypt(phone)!,
+      now);
+  }
+
+  [SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "Database name is generated internally from a Guid and safely quoted.")]
+  private async Task<string> CreateIsolatedDatabaseConnectionStringAsync(CancellationToken cancellationToken)
+  {
+    var databaseName = $"aarogya_api_test_{Guid.NewGuid():N}";
+
+    await using var connection = new NpgsqlConnection(_container.GetConnectionString());
+    await connection.OpenAsync(cancellationToken);
+
+    await using var command = connection.CreateCommand();
+    command.CommandText = $"CREATE DATABASE \"{databaseName}\";";
+    await command.ExecuteNonQueryAsync(cancellationToken);
+
+    var builder = new NpgsqlConnectionStringBuilder(_container.GetConnectionString())
+    {
+      Database = databaseName
+    };
+
+    return builder.ConnectionString;
+  }
+}
+
+internal sealed class NoOpDataSeeder : IDataSeeder
+{
+  public Task SeedAsync(CancellationToken cancellationToken = default)
+  {
+    return Task.CompletedTask;
+  }
+}
+
+internal sealed class NoOpAuditLoggingService : IAuditLoggingService
+{
+  public Task LogDataAccessAsync(
+    User actor,
+    string action,
+    string resourceType,
+    Guid? resourceId,
+    int resultStatus,
+    IReadOnlyDictionary<string, string>? data = null,
+    CancellationToken cancellationToken = default)
+  {
+    return Task.CompletedTask;
+  }
+}
+
+internal sealed class NoOpReportFileUploadService : IReportFileUploadService
+{
+  public Task<ReportUploadResponse> UploadAsync(
+    string userSub,
+    IFormFile file,
+    CancellationToken cancellationToken = default)
+  {
+    var uploadedAt = DateTimeOffset.UtcNow;
+    var response = new ReportUploadResponse(
+      Guid.NewGuid(),
+      $"RPT-{Guid.NewGuid():N}".ToUpperInvariant()[..14],
+      $"reports/{userSub}/{Guid.NewGuid():N}.pdf",
+      file.ContentType,
+      file.Length,
+      Convert.ToHexString(System.Security.Cryptography.SHA256.HashData([1, 2, 3])),
+      uploadedAt);
+
+    return Task.FromResult(response);
+  }
+}
+
+internal sealed class TestAuthHandler(
+  IOptionsMonitor<AuthenticationSchemeOptions> options,
+  ILoggerFactory logger,
+  UrlEncoder encoder)
+  : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+  public const string SchemeName = "IntegrationTestAuth";
+
+  protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+  {
+    if (!Request.Headers.TryGetValue("Authorization", out var authHeader)
+      || string.IsNullOrWhiteSpace(authHeader))
+    {
+      return Task.FromResult(AuthenticateResult.NoResult());
+    }
+
+    var value = authHeader.ToString();
+    if (!value.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+    {
+      return Task.FromResult(AuthenticateResult.Fail("Invalid authorization scheme."));
+    }
+
+    var token = value[7..].Trim();
+    if (token.Equals("invalid-token", StringComparison.Ordinal))
+    {
+      return Task.FromResult(AuthenticateResult.Fail("Invalid token."));
+    }
+
+    if (token.Equals("expired-token", StringComparison.Ordinal))
+    {
+      return Task.FromResult(AuthenticateResult.Fail("Token expired."));
+    }
+
+    var principal = token switch
+    {
+      "valid-patient" => CreatePrincipal("seed-PATIENT-IT", "Patient"),
+      "valid-doctor" => CreatePrincipal("seed-DOCTOR-IT", "Doctor"),
+      "valid-lab" => CreatePrincipal("seed-LAB-IT", "LabTechnician"),
+      _ => null
+    };
+
+    if (principal is null)
+    {
+      return Task.FromResult(AuthenticateResult.Fail("Unknown test token."));
+    }
+
+    var ticket = new AuthenticationTicket(principal, SchemeName);
+    return Task.FromResult(AuthenticateResult.Success(ticket));
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(string sub, string role)
+  {
+    var claims = new List<Claim>
+    {
+      new("sub", sub),
+      new(ClaimTypes.Role, role)
+    };
+
+    return new ClaimsPrincipal(new ClaimsIdentity(claims, SchemeName));
+  }
+}


### PR DESCRIPTION
## Summary
- add a PostgreSQL Testcontainers-backed WebApplicationFactory for API integration testing
- add core API integration tests for auth failures, consent-gated flows, RBAC checks, emergency contacts CRUD, access grants flow, and report upload endpoint contract
- add test-time service overrides to isolate external dependencies/background workers for deterministic CI execution

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #60