### PR TITLE
feat: implement push notification service with FCM support (#61)

### DIFF
--- a/src/Aarogya.Api/Configuration/FirebaseMessagingOptions.cs
+++ b/src/Aarogya.Api/Configuration/FirebaseMessagingOptions.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Aarogya.Api.Configuration;
+
+public sealed class FirebaseMessagingOptions
+{
+  public const string SectionName = "FirebaseMessaging";
+
+  public bool EnableSending { get; set; }
+
+  [Required]
+  [MaxLength(2048)]
+  public string Endpoint { get; set; } = "https://fcm.googleapis.com/fcm/send";
+
+  [MaxLength(4096)]
+  public string? ServerKey { get; set; }
+}

--- a/src/Aarogya.Api/Controllers/V1/NotificationsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/NotificationsController.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics.CodeAnalysis;
+using Aarogya.Api.Authorization;
+using Aarogya.Api.Features.V1.Common;
+using Aarogya.Api.Features.V1.Notifications;
+using Aarogya.Api.RateLimiting;
+using Aarogya.Api.Validation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace Aarogya.Api.Controllers.V1;
+
+[ApiController]
+[Route("api/v1/notifications")]
+[Authorize(Policy = AarogyaPolicies.AnyRegisteredRole)]
+[EnableRateLimiting(RateLimitPolicyNames.ApiV1)]
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "ASP.NET Core controllers must be public to be discovered by the framework.")]
+public sealed class NotificationsController(IPushNotificationService pushNotificationService) : ControllerBase
+{
+  [HttpGet("devices")]
+  [ProducesResponseType(typeof(IReadOnlyList<DeviceTokenRegistrationResponse>), StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  public async Task<IActionResult> ListDevicesAsync(CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    var devices = await pushNotificationService.ListRegisteredDevicesAsync(userSub, cancellationToken);
+    return Ok(devices);
+  }
+
+  [HttpPost("devices")]
+  [ProducesResponseType(typeof(DeviceTokenRegistrationResponse), StatusCodes.Status201Created)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  public async Task<IActionResult> RegisterDeviceAsync(
+    [FromBody] RegisterDeviceTokenRequest request,
+    CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    var registered = await pushNotificationService.RegisterDeviceAsync(userSub, request, cancellationToken);
+    return Created(new Uri($"/api/v1/notifications/devices/{Uri.EscapeDataString(registered.DeviceToken)}", UriKind.Relative), registered);
+  }
+
+  [HttpDelete("devices/{deviceToken}")]
+  [ProducesResponseType(StatusCodes.Status204NoContent)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<IActionResult> DeregisterDeviceAsync(
+    string deviceToken,
+    CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    var removed = await pushNotificationService.DeregisterDeviceAsync(
+      userSub,
+      Uri.UnescapeDataString(deviceToken),
+      cancellationToken);
+
+    return removed ? NoContent() : NotFound();
+  }
+
+  [HttpPost("test")]
+  [ProducesResponseType(typeof(PushNotificationDeliveryResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  public async Task<IActionResult> SendTestNotificationAsync(
+    [FromBody] SendPushNotificationRequest request,
+    CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    var result = await pushNotificationService.SendToCurrentUserAsync(userSub, request, cancellationToken);
+    return Ok(result);
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/FirebasePushNotificationSender.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/FirebasePushNotificationSender.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using System.Text.Json;
+using Aarogya.Api.Configuration;
+using Aarogya.Api.Security;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal sealed class FirebasePushNotificationSender(
+  HttpClient httpClient,
+  IOptions<FirebaseMessagingOptions> options,
+  ILogger<FirebasePushNotificationSender> logger)
+  : IPushNotificationSender
+{
+  private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+  public async Task<PushNotificationDeliveryResponse> SendAsync(
+    IReadOnlyList<string> deviceTokens,
+    SendPushNotificationRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(deviceTokens);
+    ArgumentNullException.ThrowIfNull(request);
+
+    if (deviceTokens.Count == 0)
+    {
+      return new PushNotificationDeliveryResponse(0, 0, 0, options.Value.EnableSending);
+    }
+
+    var settings = options.Value;
+    if (!settings.EnableSending || string.IsNullOrWhiteSpace(settings.ServerKey))
+    {
+      logger.LogInformation(
+        "Push notification sending is disabled or not configured. requestedDevices={RequestedDevices}",
+        deviceTokens.Count);
+      return new PushNotificationDeliveryResponse(deviceTokens.Count, 0, deviceTokens.Count, false);
+    }
+
+    using var requestMessage = new HttpRequestMessage(HttpMethod.Post, settings.Endpoint);
+    _ = requestMessage.Headers.TryAddWithoutValidation("Authorization", $"key={settings.ServerKey}");
+
+    var payload = new
+    {
+      registration_ids = deviceTokens,
+      priority = "high",
+      notification = new
+      {
+        title = InputSanitizer.SanitizePlainText(request.Title),
+        body = InputSanitizer.SanitizePlainText(request.Body)
+      },
+      data = InputSanitizer.SanitizeStringDictionary(request.Data)
+    };
+
+    requestMessage.Content = new StringContent(
+      JsonSerializer.Serialize(payload, SerializerOptions),
+      Encoding.UTF8,
+      "application/json");
+
+    using var response = await httpClient.SendAsync(requestMessage, cancellationToken);
+    if (!response.IsSuccessStatusCode)
+    {
+      logger.LogWarning(
+        "Push notification send failed with status {StatusCode}.",
+        (int)response.StatusCode);
+      return new PushNotificationDeliveryResponse(deviceTokens.Count, 0, deviceTokens.Count, true);
+    }
+
+    var raw = await response.Content.ReadAsStringAsync(cancellationToken);
+    if (string.IsNullOrWhiteSpace(raw))
+    {
+      return new PushNotificationDeliveryResponse(deviceTokens.Count, deviceTokens.Count, 0, true);
+    }
+
+    using var document = JsonDocument.Parse(raw);
+    var root = document.RootElement;
+    var success = root.TryGetProperty("success", out var successProp) ? successProp.GetInt32() : deviceTokens.Count;
+    var failure = root.TryGetProperty("failure", out var failureProp) ? failureProp.GetInt32() : Math.Max(deviceTokens.Count - success, 0);
+
+    return new PushNotificationDeliveryResponse(deviceTokens.Count, success, failure, true);
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/IDeviceTokenRegistry.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/IDeviceTokenRegistry.cs
@@ -1,0 +1,22 @@
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal interface IDeviceTokenRegistry
+{
+  public Task<IReadOnlyList<DeviceTokenRegistrationResponse>> ListByUserAsync(
+    string userSub,
+    CancellationToken cancellationToken = default);
+
+  public Task<DeviceTokenRegistrationResponse> UpsertAsync(
+    string userSub,
+    RegisterDeviceTokenRequest request,
+    CancellationToken cancellationToken = default);
+
+  public Task<bool> RemoveAsync(
+    string userSub,
+    string deviceToken,
+    CancellationToken cancellationToken = default);
+
+  public Task<IReadOnlyList<string>> GetDeviceTokensAsync(
+    string userSub,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/IPushNotificationSender.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/IPushNotificationSender.cs
@@ -1,0 +1,9 @@
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal interface IPushNotificationSender
+{
+  public Task<PushNotificationDeliveryResponse> SendAsync(
+    IReadOnlyList<string> deviceTokens,
+    SendPushNotificationRequest request,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/IPushNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/IPushNotificationService.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public API controller constructor for dependency injection.")]
+public interface IPushNotificationService
+{
+  public Task<IReadOnlyList<DeviceTokenRegistrationResponse>> ListRegisteredDevicesAsync(
+    string userSub,
+    CancellationToken cancellationToken = default);
+
+  public Task<DeviceTokenRegistrationResponse> RegisterDeviceAsync(
+    string userSub,
+    RegisterDeviceTokenRequest request,
+    CancellationToken cancellationToken = default);
+
+  public Task<bool> DeregisterDeviceAsync(
+    string userSub,
+    string deviceToken,
+    CancellationToken cancellationToken = default);
+
+  public Task<PushNotificationDeliveryResponse> SendToCurrentUserAsync(
+    string userSub,
+    SendPushNotificationRequest request,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/InMemoryDeviceTokenRegistry.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/InMemoryDeviceTokenRegistry.cs
@@ -1,0 +1,105 @@
+using System.Collections.Concurrent;
+using Aarogya.Api.Authentication;
+using Aarogya.Api.Security;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal sealed class InMemoryDeviceTokenRegistry(IUtcClock clock) : IDeviceTokenRegistry
+{
+  private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, DeviceRegistration>> _store =
+    new(StringComparer.Ordinal);
+
+  public Task<IReadOnlyList<DeviceTokenRegistrationResponse>> ListByUserAsync(
+    string userSub,
+    CancellationToken cancellationToken = default)
+  {
+    if (!_store.TryGetValue(userSub, out var registrations))
+    {
+      return Task.FromResult<IReadOnlyList<DeviceTokenRegistrationResponse>>([]);
+    }
+
+    var results = registrations.Values
+      .OrderByDescending(x => x.UpdatedAt)
+      .Select(Map)
+      .ToArray();
+
+    return Task.FromResult<IReadOnlyList<DeviceTokenRegistrationResponse>>(results);
+  }
+
+  public Task<DeviceTokenRegistrationResponse> UpsertAsync(
+    string userSub,
+    RegisterDeviceTokenRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    var userDevices = _store.GetOrAdd(userSub, _ => new ConcurrentDictionary<string, DeviceRegistration>(StringComparer.Ordinal));
+    var now = clock.UtcNow;
+
+    var registration = userDevices.AddOrUpdate(
+      request.DeviceToken,
+      _ => new DeviceRegistration(
+        Guid.NewGuid(),
+        request.DeviceToken,
+        request.Platform.Trim(),
+        InputSanitizer.SanitizeNullablePlainText(request.DeviceName),
+        InputSanitizer.SanitizeNullablePlainText(request.AppVersion),
+        now,
+        now),
+      (_, existing) => existing with
+      {
+        Platform = request.Platform.Trim(),
+        DeviceName = InputSanitizer.SanitizeNullablePlainText(request.DeviceName),
+        AppVersion = InputSanitizer.SanitizeNullablePlainText(request.AppVersion),
+        UpdatedAt = now
+      });
+
+    return Task.FromResult(Map(registration));
+  }
+
+  public Task<bool> RemoveAsync(
+    string userSub,
+    string deviceToken,
+    CancellationToken cancellationToken = default)
+  {
+    if (!_store.TryGetValue(userSub, out var registrations))
+    {
+      return Task.FromResult(false);
+    }
+
+    var removed = registrations.TryRemove(deviceToken, out _);
+    return Task.FromResult(removed);
+  }
+
+  public Task<IReadOnlyList<string>> GetDeviceTokensAsync(
+    string userSub,
+    CancellationToken cancellationToken = default)
+  {
+    if (!_store.TryGetValue(userSub, out var registrations))
+    {
+      return Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    var tokens = registrations.Keys.ToArray();
+    return Task.FromResult<IReadOnlyList<string>>(tokens);
+  }
+
+  private static DeviceTokenRegistrationResponse Map(DeviceRegistration registration)
+  {
+    return new DeviceTokenRegistrationResponse(
+      registration.RegistrationId,
+      registration.DeviceToken,
+      registration.Platform,
+      registration.DeviceName,
+      registration.AppVersion,
+      registration.RegisteredAt,
+      registration.UpdatedAt);
+  }
+
+  private sealed record DeviceRegistration(
+    Guid RegistrationId,
+    string DeviceToken,
+    string Platform,
+    string? DeviceName,
+    string? AppVersion,
+    DateTimeOffset RegisteredAt,
+    DateTimeOffset UpdatedAt);
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/NotificationContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/NotificationContracts.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public API action signature for model binding.")]
+public sealed record RegisterDeviceTokenRequest(
+  [property: JsonRequired] string DeviceToken,
+  [property: JsonRequired] string Platform,
+  string? DeviceName = null,
+  string? AppVersion = null);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+public sealed record DeviceTokenRegistrationResponse(
+  Guid RegistrationId,
+  string DeviceToken,
+  string Platform,
+  string? DeviceName,
+  string? AppVersion,
+  DateTimeOffset RegisteredAt,
+  DateTimeOffset UpdatedAt);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+public sealed record SendPushNotificationRequest(
+  [property: JsonRequired] string Title,
+  [property: JsonRequired] string Body,
+  IReadOnlyDictionary<string, string>? Data = null);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+public sealed record PushNotificationDeliveryResponse(
+  int RequestedDeviceCount,
+  int SuccessCount,
+  int FailureCount,
+  bool SendingEnabled);

--- a/src/Aarogya.Api/Features/V1/Notifications/PushNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/PushNotificationService.cs
@@ -1,0 +1,58 @@
+using Aarogya.Api.Security;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal sealed class PushNotificationService(
+  IDeviceTokenRegistry tokenRegistry,
+  IPushNotificationSender pushNotificationSender)
+  : IPushNotificationService
+{
+  public Task<IReadOnlyList<DeviceTokenRegistrationResponse>> ListRegisteredDevicesAsync(
+    string userSub,
+    CancellationToken cancellationToken = default)
+  {
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    return tokenRegistry.ListByUserAsync(normalizedSub, cancellationToken);
+  }
+
+  public Task<DeviceTokenRegistrationResponse> RegisterDeviceAsync(
+    string userSub,
+    RegisterDeviceTokenRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    return tokenRegistry.UpsertAsync(normalizedSub, request, cancellationToken);
+  }
+
+  public Task<bool> DeregisterDeviceAsync(
+    string userSub,
+    string deviceToken,
+    CancellationToken cancellationToken = default)
+  {
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    var normalizedToken = InputSanitizer.SanitizePlainText(deviceToken);
+    return tokenRegistry.RemoveAsync(normalizedSub, normalizedToken, cancellationToken);
+  }
+
+  public async Task<PushNotificationDeliveryResponse> SendToCurrentUserAsync(
+    string userSub,
+    SendPushNotificationRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    var tokens = await tokenRegistry.GetDeviceTokensAsync(normalizedSub, cancellationToken);
+    if (tokens.Count == 0)
+    {
+      return new PushNotificationDeliveryResponse(
+        RequestedDeviceCount: 0,
+        SuccessCount: 0,
+        FailureCount: 0,
+        SendingEnabled: false);
+    }
+
+    return await pushNotificationSender.SendAsync(tokens, request, cancellationToken);
+  }
+}

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Aarogya.Api.Features.V1.AccessGrants;
 using Aarogya.Api.Features.V1.Consents;
 using Aarogya.Api.Features.V1.EmergencyContacts;
+using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Api.Features.V1.Reports;
 using Aarogya.Api.Features.V1.Users;
 
@@ -18,6 +19,12 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddScoped<IReportVirusScanProcessor, ReportVirusScanProcessor>();
     services.AddSingleton<IReportVirusScanner, ClamAvReportVirusScanner>();
     services.AddScoped<IPatientNotificationService, LoggingPatientNotificationService>();
+    services.AddSingleton<IDeviceTokenRegistry, InMemoryDeviceTokenRegistry>();
+    services.AddScoped<IPushNotificationService, PushNotificationService>();
+    services.AddHttpClient<IPushNotificationSender, FirebasePushNotificationSender>(client =>
+    {
+      client.Timeout = TimeSpan.FromSeconds(10);
+    });
     services.AddHostedService<S3UploadNotificationConfiguratorHostedService>();
     services.AddHostedService<S3UploadEventConsumerHostedService>();
     services.AddHostedService<ClamAvDefinitionsUpdaterHostedService>();

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -84,6 +84,11 @@ builder.Services
   .ValidateDataAnnotations();
 
 builder.Services
+  .AddOptionsWithValidateOnStart<FirebaseMessagingOptions>()
+  .BindConfiguration(FirebaseMessagingOptions.SectionName)
+  .ValidateDataAnnotations();
+
+builder.Services
   .AddOptionsWithValidateOnStart<AccessGrantOptions>()
   .BindConfiguration(AccessGrantOptions.SectionName)
   .ValidateDataAnnotations();

--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -2,6 +2,7 @@ using Aarogya.Api.Authorization;
 using Aarogya.Api.Controllers;
 using Aarogya.Api.Features.V1.AccessGrants;
 using Aarogya.Api.Features.V1.EmergencyContacts;
+using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Api.Features.V1.Reports;
 using Aarogya.Api.Features.V1.Users;
 using FluentValidation;
@@ -392,5 +393,49 @@ internal sealed class UpdateUserProfileRequestValidator : AbstractValidator<Upda
       || request.Address is not null
       || request.BloodGroup is not null
       || request.DateOfBirth.HasValue;
+  }
+}
+
+internal sealed class RegisterDeviceTokenRequestValidator : AbstractValidator<RegisterDeviceTokenRequest>
+{
+  private static readonly string[] SupportedPlatforms = ["ios", "android"];
+
+  public RegisterDeviceTokenRequestValidator()
+  {
+    RuleFor(x => x.DeviceToken).NotEmpty().MaximumLength(4096);
+    RuleFor(x => x.Platform)
+      .NotEmpty()
+      .Must(platform => SupportedPlatforms.Contains(platform.Trim(), StringComparer.OrdinalIgnoreCase))
+      .WithMessage("Platform must be ios or android.");
+    RuleFor(x => x.DeviceName).MaximumLength(120).When(x => x.DeviceName is not null);
+    RuleFor(x => x.AppVersion).MaximumLength(40).When(x => x.AppVersion is not null);
+  }
+}
+
+internal sealed class SendPushNotificationRequestValidator : AbstractValidator<SendPushNotificationRequest>
+{
+  public SendPushNotificationRequestValidator()
+  {
+    RuleFor(x => x.Title).NotEmpty().MaximumLength(200);
+    RuleFor(x => x.Body).NotEmpty().MaximumLength(2000);
+    RuleFor(x => x.Data).Must(HaveValidMetadata).WithMessage("Data keys and values must be non-empty and within size limits.");
+  }
+
+  private static bool HaveValidMetadata(IReadOnlyDictionary<string, string>? data)
+  {
+    if (data is null)
+    {
+      return true;
+    }
+
+    if (data.Count > 25)
+    {
+      return false;
+    }
+
+    return data.All(pair =>
+      !string.IsNullOrWhiteSpace(pair.Key)
+      && pair.Key.Length <= 100
+      && pair.Value.Length <= 2000);
   }
 }

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -157,6 +157,11 @@
     "DefaultKeyLifetimeDays": 365,
     "RotationOverlapMinutes": 1440
   },
+  "FirebaseMessaging": {
+    "EnableSending": false,
+    "Endpoint": "https://fcm.googleapis.com/fcm/send",
+    "ServerKey": "SET_VIA_ENV_VAR"
+  },
   "AccessGrants": {
     "DefaultExpiryDays": 30,
     "MaxExpiryDays": 180

--- a/src/Aarogya.Api/secrets.template.json
+++ b/src/Aarogya.Api/secrets.template.json
@@ -25,6 +25,8 @@
   "Aws:Cognito:AppClientId": "your-cognito-app-client-id",
   "Aws:Cognito:SocialIdentityProviders:Google:ClientId": "your-google-client-id",
   "Aws:Cognito:SocialIdentityProviders:Google:ClientSecret": "your-google-client-secret",
+  "FirebaseMessaging:EnableSending": "false",
+  "FirebaseMessaging:ServerKey": "your-fcm-legacy-server-key",
   "Encryption:KmsKeyId": "your-kms-key-id-or-arn",
   "Encryption:ActiveKeyId": "kms-primary",
   "Encryption:LocalDataKey": "local-fallback-key-for-dev-only",

--- a/tests/Aarogya.Api.Tests/NotificationsControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/NotificationsControllerTests.cs
@@ -1,0 +1,92 @@
+using System.Security.Claims;
+using Aarogya.Api.Controllers.V1;
+using Aarogya.Api.Features.V1.Notifications;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class NotificationsControllerTests
+{
+  [Fact]
+  public async Task RegisterDeviceAsync_ShouldReturnUnauthorized_WhenSubjectMissingAsync()
+  {
+    var controller = CreateController(Mock.Of<IPushNotificationService>(), new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.RegisterDeviceAsync(
+      new RegisterDeviceTokenRequest("token", "ios"),
+      CancellationToken.None);
+
+    result.Should().BeOfType<UnauthorizedResult>();
+  }
+
+  [Fact]
+  public async Task RegisterDeviceAsync_ShouldReturnCreated_WhenValidAsync()
+  {
+    var service = new Mock<IPushNotificationService>();
+    var response = new DeviceTokenRegistrationResponse(
+      Guid.NewGuid(),
+      "token-1",
+      "ios",
+      "iPhone",
+      "1.0.0",
+      DateTimeOffset.UtcNow,
+      DateTimeOffset.UtcNow);
+    service
+      .Setup(x => x.RegisterDeviceAsync("seed-PATIENT-IT", It.IsAny<RegisterDeviceTokenRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(response);
+
+    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-IT"));
+
+    var result = await controller.RegisterDeviceAsync(
+      new RegisterDeviceTokenRequest("token-1", "ios", "iPhone", "1.0.0"),
+      CancellationToken.None);
+
+    var created = result.Should().BeOfType<CreatedResult>().Subject;
+    created.Value.Should().BeEquivalentTo(response);
+  }
+
+  [Fact]
+  public async Task SendTestNotificationAsync_ShouldReturnOk_WhenUserAuthenticatedAsync()
+  {
+    var service = new Mock<IPushNotificationService>();
+    var response = new PushNotificationDeliveryResponse(1, 1, 0, true);
+    service
+      .Setup(x => x.SendToCurrentUserAsync("seed-PATIENT-IT", It.IsAny<SendPushNotificationRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(response);
+
+    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-IT"));
+
+    var result = await controller.SendTestNotificationAsync(
+      new SendPushNotificationRequest("Test", "Body"),
+      CancellationToken.None);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    ok.Value.Should().BeEquivalentTo(response);
+  }
+
+  private static NotificationsController CreateController(IPushNotificationService service, ClaimsPrincipal user)
+  {
+    return new NotificationsController(service)
+    {
+      ControllerContext = new ControllerContext
+      {
+        HttpContext = new DefaultHttpContext
+        {
+          User = user
+        }
+      }
+    };
+  }
+
+  private static ClaimsPrincipal CreateUser(string sub)
+  {
+    return new ClaimsPrincipal(new ClaimsIdentity(
+    [
+      new Claim("sub", sub)
+    ], "TestAuth"));
+  }
+}

--- a/tests/Aarogya.Api.Tests/PushNotificationServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/PushNotificationServiceTests.cs
@@ -1,0 +1,73 @@
+using Aarogya.Api.Authentication;
+using Aarogya.Api.Features.V1.Notifications;
+using FluentAssertions;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class PushNotificationServiceTests
+{
+  [Fact]
+  public async Task RegisterDeviceAsync_ShouldPersistAndListRegistrationAsync()
+  {
+    var registry = new InMemoryDeviceTokenRegistry(new SystemUtcClock());
+    var service = new PushNotificationService(registry, new FakePushNotificationSender());
+
+    var registration = await service.RegisterDeviceAsync(
+      "seed-PATIENT-IT",
+      new RegisterDeviceTokenRequest("token-1", "ios", "iPhone", "1.0.0"));
+
+    var listed = await service.ListRegisteredDevicesAsync("seed-PATIENT-IT");
+
+    registration.DeviceToken.Should().Be("token-1");
+    registration.Platform.Should().Be("ios");
+    listed.Should().ContainSingle(x => x.DeviceToken == "token-1" && x.Platform == "ios");
+  }
+
+  [Fact]
+  public async Task DeregisterDeviceAsync_ShouldReturnFalse_WhenTokenMissingAsync()
+  {
+    var registry = new InMemoryDeviceTokenRegistry(new SystemUtcClock());
+    var service = new PushNotificationService(registry, new FakePushNotificationSender());
+
+    var removed = await service.DeregisterDeviceAsync("seed-PATIENT-IT", "missing-token");
+
+    removed.Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task SendToCurrentUserAsync_ShouldSendToRegisteredTokensAsync()
+  {
+    var registry = new InMemoryDeviceTokenRegistry(new SystemUtcClock());
+    var sender = new FakePushNotificationSender();
+
+    var service = new PushNotificationService(registry, sender);
+    await service.RegisterDeviceAsync("seed-PATIENT-IT", new RegisterDeviceTokenRequest("token-1", "ios"));
+    await service.RegisterDeviceAsync("seed-PATIENT-IT", new RegisterDeviceTokenRequest("token-2", "android"));
+
+    var result = await service.SendToCurrentUserAsync(
+      "seed-PATIENT-IT",
+      new SendPushNotificationRequest("Lab Report Ready", "Your report is now available."));
+
+    result.SuccessCount.Should().Be(2);
+    sender.LastTokens.Should().Contain(["token-1", "token-2"]);
+    sender.InvocationCount.Should().Be(1);
+  }
+
+  private sealed class FakePushNotificationSender : IPushNotificationSender
+  {
+    public int InvocationCount { get; private set; }
+
+    public IReadOnlyList<string> LastTokens { get; private set; } = [];
+
+    public Task<PushNotificationDeliveryResponse> SendAsync(
+      IReadOnlyList<string> deviceTokens,
+      SendPushNotificationRequest request,
+      CancellationToken cancellationToken = default)
+    {
+      InvocationCount++;
+      LastTokens = deviceTokens.ToArray();
+      return Task.FromResult(new PushNotificationDeliveryResponse(deviceTokens.Count, deviceTokens.Count, 0, true));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Notifications v1 feature for device token registration, listing, and deregistration (iOS + Android)
- add push notification delivery API with configurable payload and FCM sender integration
- add in-memory token registry and test-safe sender behavior when FCM sending is disabled
- wire Firebase messaging options into configuration and DI
- add controller/service tests for notification flows

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #61