### PR TITLE
feat: add SES transactional email notification service (#62)

### DIFF
--- a/src/Aarogya.Api/Configuration/EmailNotificationsOptions.cs
+++ b/src/Aarogya.Api/Configuration/EmailNotificationsOptions.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Aarogya.Api.Configuration;
+
+public sealed class EmailNotificationsOptions
+{
+  public const string SectionName = "EmailNotifications";
+
+  public bool EnableTransactionalEmails { get; set; }
+
+  [System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Design",
+    "CA1056:URI-like properties should not be strings",
+    Justification = "Configuration binding requires string type.")]
+  [Required]
+  [Url]
+  [MaxLength(1024)]
+  public string UnsubscribeBaseUrl { get; set; } = "https://aarogya.app/unsubscribe";
+}

--- a/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantService.cs
+++ b/src/Aarogya.Api/Features/V1/AccessGrants/AccessGrantService.cs
@@ -1,6 +1,7 @@
 using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Configuration;
+using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Api.Security;
 using Aarogya.Domain.Entities;
 using Aarogya.Domain.Enums;
@@ -17,6 +18,7 @@ internal sealed class AccessGrantService(
   IAccessGrantRepository accessGrantRepository,
   IUnitOfWork unitOfWork,
   IAuditLoggingService auditLoggingService,
+  ITransactionalEmailNotificationService transactionalEmailNotificationService,
   IOptions<AccessGrantOptions> options,
   IUtcClock clock)
   : IAccessGrantService
@@ -170,6 +172,12 @@ internal sealed class AccessGrantService(
         ["doctorUserId"] = doctor.Id.ToString("D"),
         ["allReports"] = request.AllReports.ToString()
       },
+      cancellationToken);
+
+    await transactionalEmailNotificationService.SendAccessGrantedAsync(
+      patient,
+      doctor,
+      grant,
       cancellationToken);
 
     return new AccessGrantResponse(

--- a/src/Aarogya.Api/Features/V1/EmergencyContacts/EmergencyContactService.cs
+++ b/src/Aarogya.Api/Features/V1/EmergencyContacts/EmergencyContactService.cs
@@ -1,5 +1,6 @@
 using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
+using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Api.Security;
 using Aarogya.Domain.Entities;
 using Aarogya.Domain.Enums;
@@ -13,6 +14,7 @@ internal sealed class EmergencyContactService(
   IEmergencyContactRepository emergencyContactRepository,
   IUnitOfWork unitOfWork,
   IAuditLoggingService auditLoggingService,
+  ITransactionalEmailNotificationService transactionalEmailNotificationService,
   IUtcClock clock)
   : IEmergencyContactService
 {
@@ -74,6 +76,12 @@ internal sealed class EmergencyContactService(
       contact.Id,
       201,
       cancellationToken: cancellationToken);
+
+    await transactionalEmailNotificationService.SendEmergencyAccessEventAsync(
+      patient,
+      contact,
+      "created",
+      cancellationToken);
     return Map(contact);
   }
 
@@ -108,6 +116,12 @@ internal sealed class EmergencyContactService(
       contact.Id,
       200,
       cancellationToken: cancellationToken);
+
+    await transactionalEmailNotificationService.SendEmergencyAccessEventAsync(
+      patient,
+      contact,
+      "updated",
+      cancellationToken);
     return Map(contact);
   }
 
@@ -131,6 +145,12 @@ internal sealed class EmergencyContactService(
       contact.Id,
       200,
       cancellationToken: cancellationToken);
+
+    await transactionalEmailNotificationService.SendEmergencyAccessEventAsync(
+      patient,
+      contact,
+      "deleted",
+      cancellationToken);
     return true;
   }
 

--- a/src/Aarogya.Api/Features/V1/Notifications/ITransactionalEmailNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/ITransactionalEmailNotificationService.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by service constructors and unit-test mocking.")]
+public interface ITransactionalEmailNotificationService
+{
+  public Task SendReportUploadedAsync(
+    User patient,
+    Report report,
+    CancellationToken cancellationToken = default);
+
+  public Task SendAccessGrantedAsync(
+    User patient,
+    User doctor,
+    AccessGrant grant,
+    CancellationToken cancellationToken = default);
+
+  public Task SendEmergencyAccessEventAsync(
+    User patient,
+    EmergencyContact contact,
+    string action,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/ITransactionalEmailSender.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/ITransactionalEmailSender.cs
@@ -1,0 +1,12 @@
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal interface ITransactionalEmailSender
+{
+  public Task SendAsync(
+    string toEmail,
+    string? toName,
+    string subject,
+    string htmlBody,
+    string textBody,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/SesTransactionalEmailSender.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/SesTransactionalEmailSender.cs
@@ -1,0 +1,73 @@
+using Aarogya.Api.Configuration;
+using Amazon.SimpleEmailV2;
+using Amazon.SimpleEmailV2.Model;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal sealed class SesTransactionalEmailSender(
+  IAmazonSimpleEmailServiceV2 sesClient,
+  IOptions<AwsOptions> awsOptions,
+  IOptions<EmailNotificationsOptions> emailOptions,
+  ILogger<SesTransactionalEmailSender> logger)
+  : ITransactionalEmailSender
+{
+  private readonly AwsOptions _aws = awsOptions.Value;
+  private readonly EmailNotificationsOptions _email = emailOptions.Value;
+
+  public async Task SendAsync(
+    string toEmail,
+    string? toName,
+    string subject,
+    string htmlBody,
+    string textBody,
+    CancellationToken cancellationToken = default)
+  {
+    if (!_email.EnableTransactionalEmails)
+    {
+      logger.LogInformation("Transactional email disabled. Skipping email for {Recipient}.", toEmail);
+      return;
+    }
+
+    if (string.IsNullOrWhiteSpace(toEmail))
+    {
+      return;
+    }
+
+    try
+    {
+      var displayName = string.IsNullOrWhiteSpace(toName) ? toEmail : $"{toName} <{toEmail}>";
+      var senderName = string.IsNullOrWhiteSpace(_aws.Ses.SenderName) ? "Aarogya" : _aws.Ses.SenderName.Trim();
+      var sender = string.IsNullOrWhiteSpace(_aws.Ses.SenderEmail)
+        ? throw new InvalidOperationException("Aws:Ses:SenderEmail is required for transactional emails.")
+        : $"{senderName} <{_aws.Ses.SenderEmail.Trim()}>";
+
+      var request = new SendEmailRequest
+      {
+        FromEmailAddress = sender,
+        Destination = new Destination
+        {
+          ToAddresses = [displayName]
+        },
+        Content = new EmailContent
+        {
+          Simple = new Message
+          {
+            Subject = new Content { Data = subject, Charset = "UTF-8" },
+            Body = new Body
+            {
+              Html = new Content { Data = htmlBody, Charset = "UTF-8" },
+              Text = new Content { Data = textBody, Charset = "UTF-8" }
+            }
+          }
+        }
+      };
+
+      _ = await sesClient.SendEmailAsync(request, cancellationToken);
+    }
+    catch (Exception ex)
+    {
+      logger.LogWarning(ex, "Failed to send transactional email to {Recipient}.", toEmail);
+    }
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/TransactionalEmailNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/TransactionalEmailNotificationService.cs
@@ -1,0 +1,84 @@
+using Aarogya.Api.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal sealed class TransactionalEmailNotificationService(
+  ITransactionalEmailSender emailSender,
+  IOptions<EmailNotificationsOptions> options)
+  : ITransactionalEmailNotificationService
+{
+  private readonly EmailNotificationsOptions _options = options.Value;
+
+  public Task SendReportUploadedAsync(
+    Domain.Entities.User patient,
+    Domain.Entities.Report report,
+    CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(patient.Email))
+    {
+      return Task.CompletedTask;
+    }
+
+    var unsubscribeUrl = BuildUnsubscribeUrl(patient.ExternalAuthId, patient.Email);
+    var template = TransactionalEmailTemplateBuilder.BuildReportUploaded(patient, report, unsubscribeUrl);
+    return emailSender.SendAsync(
+      patient.Email,
+      $"{patient.FirstName} {patient.LastName}".Trim(),
+      template.Subject,
+      template.HtmlBody,
+      template.TextBody,
+      cancellationToken);
+  }
+
+  public Task SendAccessGrantedAsync(
+    Domain.Entities.User patient,
+    Domain.Entities.User doctor,
+    Domain.Entities.AccessGrant grant,
+    CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(doctor.Email))
+    {
+      return Task.CompletedTask;
+    }
+
+    var unsubscribeUrl = BuildUnsubscribeUrl(doctor.ExternalAuthId, doctor.Email);
+    var template = TransactionalEmailTemplateBuilder.BuildAccessGranted(doctor, patient, grant, unsubscribeUrl);
+    return emailSender.SendAsync(
+      doctor.Email,
+      $"{doctor.FirstName} {doctor.LastName}".Trim(),
+      template.Subject,
+      template.HtmlBody,
+      template.TextBody,
+      cancellationToken);
+  }
+
+  public Task SendEmergencyAccessEventAsync(
+    Domain.Entities.User patient,
+    Domain.Entities.EmergencyContact contact,
+    string action,
+    CancellationToken cancellationToken = default)
+  {
+    if (string.IsNullOrWhiteSpace(patient.Email))
+    {
+      return Task.CompletedTask;
+    }
+
+    var unsubscribeUrl = BuildUnsubscribeUrl(patient.ExternalAuthId, patient.Email);
+    var template = TransactionalEmailTemplateBuilder.BuildEmergencyAccessEvent(patient, contact, action, unsubscribeUrl);
+    return emailSender.SendAsync(
+      patient.Email,
+      $"{patient.FirstName} {patient.LastName}".Trim(),
+      template.Subject,
+      template.HtmlBody,
+      template.TextBody,
+      cancellationToken);
+  }
+
+  private string BuildUnsubscribeUrl(string? userSub, string email)
+  {
+    var baseUrl = _options.UnsubscribeBaseUrl.TrimEnd('/');
+    var identity = string.IsNullOrWhiteSpace(userSub) ? email : userSub;
+    return $"{baseUrl}?user={Uri.EscapeDataString(identity)}";
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/TransactionalEmailTemplateBuilder.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/TransactionalEmailTemplateBuilder.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal static class TransactionalEmailTemplateBuilder
+{
+  public static (string Subject, string HtmlBody, string TextBody) BuildReportUploaded(
+    User patient,
+    Report report,
+    string unsubscribeUrl)
+  {
+    var safeName = WebUtility.HtmlEncode($"{patient.FirstName} {patient.LastName}".Trim());
+    var safeReportNumber = WebUtility.HtmlEncode(report.ReportNumber);
+    var subject = $"Aarogya: New Report Uploaded ({report.ReportNumber})";
+    var html = $$"""
+                 <html><body style="font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+                 <h2>New Medical Report Uploaded</h2>
+                 <p>Hello {{safeName}},</p>
+                 <p>Your report <strong>{{safeReportNumber}}</strong> has been uploaded to your Aarogya account.</p>
+                 <p>You can review it in the app under Reports.</p>
+                 {{BuildUnsubscribeFooter(unsubscribeUrl)}}
+                 </body></html>
+                 """;
+    var text = $"Hello {patient.FirstName},\nYour report {report.ReportNumber} has been uploaded.\nUnsubscribe: {unsubscribeUrl}";
+    return (subject, html, text);
+  }
+
+  public static (string Subject, string HtmlBody, string TextBody) BuildAccessGranted(
+    User doctor,
+    User patient,
+    AccessGrant grant,
+    string unsubscribeUrl)
+  {
+    var safeDoctorName = WebUtility.HtmlEncode($"{doctor.FirstName} {doctor.LastName}".Trim());
+    var safePatientName = WebUtility.HtmlEncode($"{patient.FirstName} {patient.LastName}".Trim());
+    var safePurpose = WebUtility.HtmlEncode(grant.GrantReason ?? "care");
+    var subject = $"Aarogya: Access Granted by {patient.FirstName} {patient.LastName}";
+    var html = $$"""
+                 <html><body style="font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+                 <h2>Medical Data Access Granted</h2>
+                 <p>Hello {{safeDoctorName}},</p>
+                 <p>{{safePatientName}} has granted you medical data access for: <strong>{{safePurpose}}</strong>.</p>
+                 <p>This access starts immediately and will expire on {{grant.ExpiresAt:yyyy-MM-dd}}.</p>
+                 {{BuildUnsubscribeFooter(unsubscribeUrl)}}
+                 </body></html>
+                 """;
+    var text = $"Hello {doctor.FirstName},\n{patient.FirstName} {patient.LastName} granted access for '{grant.GrantReason}'.\nUnsubscribe: {unsubscribeUrl}";
+    return (subject, html, text);
+  }
+
+  public static (string Subject, string HtmlBody, string TextBody) BuildEmergencyAccessEvent(
+    User patient,
+    EmergencyContact contact,
+    string action,
+    string unsubscribeUrl)
+  {
+    var safePatientName = WebUtility.HtmlEncode($"{patient.FirstName} {patient.LastName}".Trim());
+    var safeContactName = WebUtility.HtmlEncode(contact.Name);
+    var safeAction = WebUtility.HtmlEncode(action);
+    var subject = $"Aarogya: Emergency Contact {action}";
+    var html = $$"""
+                 <html><body style="font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+                 <h2>Emergency Access Update</h2>
+                 <p>Hello {{safePatientName}},</p>
+                 <p>Your emergency contact <strong>{{safeContactName}}</strong> was <strong>{{safeAction}}</strong>.</p>
+                 <p>If this was not you, please review your account security settings immediately.</p>
+                 {{BuildUnsubscribeFooter(unsubscribeUrl)}}
+                 </body></html>
+                 """;
+    var text = $"Hello {patient.FirstName},\nEmergency contact {contact.Name} was {action}.\nUnsubscribe: {unsubscribeUrl}";
+    return (subject, html, text);
+  }
+
+  private static string BuildUnsubscribeFooter(string unsubscribeUrl)
+  {
+    var safeUrl = WebUtility.HtmlEncode(unsubscribeUrl);
+    return $"""
+            <hr style="margin-top:24px;" />
+            <p style="font-size:12px;color:#6b7280;">
+              To unsubscribe from these notifications, click
+              <a href="{safeUrl}" target="_blank" rel="noopener noreferrer">here</a>.
+            </p>
+            """;
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Reports/LoggingPatientNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/LoggingPatientNotificationService.cs
@@ -1,11 +1,14 @@
+using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Domain.Entities;
 
 namespace Aarogya.Api.Features.V1.Reports;
 
-internal sealed class LoggingPatientNotificationService(ILogger<LoggingPatientNotificationService> logger)
+internal sealed class LoggingPatientNotificationService(
+  ILogger<LoggingPatientNotificationService> logger,
+  ITransactionalEmailNotificationService transactionalEmailNotificationService)
   : IPatientNotificationService
 {
-  public Task NotifyReportUploadedAsync(
+  public async Task NotifyReportUploadedAsync(
     User patient,
     Report report,
     CancellationToken cancellationToken = default)
@@ -15,6 +18,10 @@ internal sealed class LoggingPatientNotificationService(ILogger<LoggingPatientNo
       patient.Id,
       report.Id,
       report.ReportNumber);
-    return Task.CompletedTask;
+
+    await transactionalEmailNotificationService.SendReportUploadedAsync(
+      patient,
+      report,
+      cancellationToken);
   }
 }

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddScoped<IReportChecksumVerificationService, S3ReportChecksumVerificationService>();
     services.AddScoped<IReportVirusScanProcessor, ReportVirusScanProcessor>();
     services.AddSingleton<IReportVirusScanner, ClamAvReportVirusScanner>();
+    services.AddScoped<ITransactionalEmailNotificationService, TransactionalEmailNotificationService>();
+    services.AddScoped<ITransactionalEmailSender, SesTransactionalEmailSender>();
     services.AddScoped<IPatientNotificationService, LoggingPatientNotificationService>();
     services.AddSingleton<IDeviceTokenRegistry, InMemoryDeviceTokenRegistry>();
     services.AddScoped<IPushNotificationService, PushNotificationService>();

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -89,6 +89,11 @@ builder.Services
   .ValidateDataAnnotations();
 
 builder.Services
+  .AddOptionsWithValidateOnStart<EmailNotificationsOptions>()
+  .BindConfiguration(EmailNotificationsOptions.SectionName)
+  .ValidateDataAnnotations();
+
+builder.Services
   .AddOptionsWithValidateOnStart<AccessGrantOptions>()
   .BindConfiguration(AccessGrantOptions.SectionName)
   .ValidateDataAnnotations();

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -162,6 +162,10 @@
     "Endpoint": "https://fcm.googleapis.com/fcm/send",
     "ServerKey": "SET_VIA_ENV_VAR"
   },
+  "EmailNotifications": {
+    "EnableTransactionalEmails": false,
+    "UnsubscribeBaseUrl": "https://aarogya.app/unsubscribe"
+  },
   "AccessGrants": {
     "DefaultExpiryDays": 30,
     "MaxExpiryDays": 180

--- a/src/Aarogya.Api/secrets.template.json
+++ b/src/Aarogya.Api/secrets.template.json
@@ -27,6 +27,8 @@
   "Aws:Cognito:SocialIdentityProviders:Google:ClientSecret": "your-google-client-secret",
   "FirebaseMessaging:EnableSending": "false",
   "FirebaseMessaging:ServerKey": "your-fcm-legacy-server-key",
+  "EmailNotifications:EnableTransactionalEmails": "true",
+  "EmailNotifications:UnsubscribeBaseUrl": "https://aarogya.app/unsubscribe",
   "Encryption:KmsKeyId": "your-kms-key-id-or-arn",
   "Encryption:ActiveKeyId": "kms-primary",
   "Encryption:LocalDataKey": "local-fallback-key-for-dev-only",

--- a/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/AccessGrantServiceTests.cs
@@ -2,6 +2,7 @@ using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Configuration;
 using Aarogya.Api.Features.V1.AccessGrants;
+using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Domain.Entities;
 using Aarogya.Domain.Enums;
 using Aarogya.Domain.Repositories;
@@ -46,6 +47,7 @@ public sealed class AccessGrantServiceTests
       accessGrantRepository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions
       {
         DefaultExpiryDays = 30,
@@ -95,6 +97,7 @@ public sealed class AccessGrantServiceTests
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
@@ -134,6 +137,7 @@ public sealed class AccessGrantServiceTests
       accessGrantRepository.Object,
       unitOfWork.Object,
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
@@ -180,6 +184,7 @@ public sealed class AccessGrantServiceTests
       accessGrantRepository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(now));
 
@@ -208,6 +213,7 @@ public sealed class AccessGrantServiceTests
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
@@ -240,6 +246,7 @@ public sealed class AccessGrantServiceTests
       Mock.Of<IAccessGrantRepository>(),
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions
       {
         DefaultExpiryDays = 30,
@@ -339,6 +346,7 @@ public sealed class AccessGrantServiceTests
       accessGrantRepository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(now));
 
@@ -376,6 +384,7 @@ public sealed class AccessGrantServiceTests
       accessGrantRepository.Object,
       unitOfWork.Object,
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       Options.Create(new AccessGrantOptions()),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 

--- a/tests/Aarogya.Api.Tests/EmergencyContactServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/EmergencyContactServiceTests.cs
@@ -1,6 +1,7 @@
 using Aarogya.Api.Auditing;
 using Aarogya.Api.Authentication;
 using Aarogya.Api.Features.V1.EmergencyContacts;
+using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Domain.Entities;
 using Aarogya.Domain.Enums;
 using Aarogya.Domain.Repositories;
@@ -44,6 +45,7 @@ public sealed class EmergencyContactServiceTests
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero)));
 
     var response = await service.AddForUserAsync(
@@ -87,6 +89,7 @@ public sealed class EmergencyContactServiceTests
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var action = async () => await service.AddForUserAsync(
@@ -131,6 +134,7 @@ public sealed class EmergencyContactServiceTests
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var updated = await service.UpdateForUserAsync(
@@ -169,6 +173,7 @@ public sealed class EmergencyContactServiceTests
       emergencyContactRepository.Object,
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var deleted = await service.DeleteForUserAsync("seed-PATIENT-1", Guid.NewGuid(), CancellationToken.None);
@@ -196,6 +201,7 @@ public sealed class EmergencyContactServiceTests
       Mock.Of<IEmergencyContactRepository>(),
       Mock.Of<IUnitOfWork>(),
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var action = async () => await service.AddForUserAsync(
@@ -242,6 +248,7 @@ public sealed class EmergencyContactServiceTests
       emergencyContactRepository.Object,
       unitOfWork.Object,
       Mock.Of<IAuditLoggingService>(),
+      Mock.Of<ITransactionalEmailNotificationService>(),
       new FixedUtcClock(DateTimeOffset.UtcNow));
 
     var deleted = await service.DeleteForUserAsync("seed-PATIENT-1", contact.Id, CancellationToken.None);


### PR DESCRIPTION
## Summary
- add SES transactional email sender with HTML + text body support and unsubscribe link footer
- add notification orchestration for report upload, access grant, and emergency contact events
- wire EmailNotifications options and configuration defaults
- trigger notification sends from report upload, access-grant create, and emergency-contact create/update/delete paths
- update service unit tests for new notification dependency wiring

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

Closes #62