### PR TITLE
feat: implement issue #64 notification preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ POST   /api/v1/emergency-contacts            Create emergency contact
 DELETE /api/v1/emergency-contacts/{contactId} Delete emergency contact
 GET    /api/v1/consents                      List current user consent states
 PUT    /api/v1/consents/{purpose}            Grant/withdraw consent for a purpose
+GET    /api/v1/notifications/preferences     Get notification preferences
+PUT    /api/v1/notifications/preferences     Update notification preferences
 ```
 
 ## 🔐 Authentication
@@ -339,6 +341,27 @@ Configuration (`appsettings*.json`):
   }
 }
 ```
+
+### Notification Preferences
+Issue #64 adds per-user notification preferences by event and channel.
+
+Supported events:
+- `report_uploaded`
+- `access_granted`
+- `emergency_access`
+
+Supported channels:
+- `push`
+- `email`
+- `sms`
+
+API:
+- `GET /api/v1/notifications/preferences`
+- `PUT /api/v1/notifications/preferences`
+
+Behavior:
+- default preferences are all-enabled on first user interaction
+- push/email/sms notification services evaluate preferences before sending
 
 ### CloudFront Report CDN
 Issue #58 adds CloudFront CDN infrastructure and runtime integration for report downloads:

--- a/src/Aarogya.Api/Controllers/V1/NotificationsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/NotificationsController.cs
@@ -20,6 +20,39 @@ namespace Aarogya.Api.Controllers.V1;
   Justification = "ASP.NET Core controllers must be public to be discovered by the framework.")]
 public sealed class NotificationsController(IPushNotificationService pushNotificationService) : ControllerBase
 {
+  [HttpGet("preferences")]
+  [ProducesResponseType(typeof(NotificationPreferencesResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  public async Task<IActionResult> GetPreferencesAsync(CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    var preferences = await pushNotificationService.GetPreferencesAsync(userSub, cancellationToken);
+    return Ok(preferences);
+  }
+
+  [HttpPut("preferences")]
+  [ProducesResponseType(typeof(NotificationPreferencesResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  public async Task<IActionResult> UpdatePreferencesAsync(
+    [FromBody] UpdateNotificationPreferencesRequest request,
+    CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    var updated = await pushNotificationService.UpdatePreferencesAsync(userSub, request, cancellationToken);
+    return Ok(updated);
+  }
+
   [HttpGet("devices")]
   [ProducesResponseType(typeof(IReadOnlyList<DeviceTokenRegistrationResponse>), StatusCodes.Status200OK)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -81,7 +114,8 @@ public sealed class NotificationsController(IPushNotificationService pushNotific
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
   public async Task<IActionResult> SendTestNotificationAsync(
     [FromBody] SendPushNotificationRequest request,
-    CancellationToken cancellationToken)
+    [FromQuery] string eventType = NotificationEventTypes.ReportUploaded,
+    CancellationToken cancellationToken = default)
   {
     var userSub = User.GetSubjectOrNull();
     if (userSub is null)
@@ -89,7 +123,31 @@ public sealed class NotificationsController(IPushNotificationService pushNotific
       return Unauthorized();
     }
 
-    var result = await pushNotificationService.SendToCurrentUserAsync(userSub, request, cancellationToken);
+    if (!IsSupportedEventType(eventType))
+    {
+      return BadRequest(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["eventType"] =
+          [
+            "eventType must be one of: report_uploaded, access_granted, emergency_access."
+          ]
+        }));
+    }
+
+    var result = await pushNotificationService.SendToCurrentUserAsync(
+      userSub,
+      eventType,
+      request,
+      cancellationToken);
     return Ok(result);
+  }
+
+  private static bool IsSupportedEventType(string eventType)
+  {
+    return string.Equals(eventType, NotificationEventTypes.ReportUploaded, StringComparison.Ordinal)
+      || string.Equals(eventType, NotificationEventTypes.AccessGranted, StringComparison.Ordinal)
+      || string.Equals(eventType, NotificationEventTypes.EmergencyAccess, StringComparison.Ordinal);
   }
 }

--- a/src/Aarogya.Api/Features/V1/Notifications/CriticalSmsNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/CriticalSmsNotificationService.cs
@@ -4,6 +4,7 @@ namespace Aarogya.Api.Features.V1.Notifications;
 
 internal sealed class CriticalSmsNotificationService(
   ISmsSender smsSender,
+  INotificationPreferenceService preferenceService,
   ILogger<CriticalSmsNotificationService> logger)
   : ICriticalSmsNotificationService
 {
@@ -18,8 +19,14 @@ internal sealed class CriticalSmsNotificationService(
       return;
     }
 
+    var userSub = string.IsNullOrWhiteSpace(patient.ExternalAuthId) ? patient.Id.ToString("D") : patient.ExternalAuthId;
+    if (!await preferenceService.IsEnabledAsync(userSub, NotificationEventTypes.EmergencyAccess, NotificationChannels.Sms, cancellationToken))
+    {
+      return;
+    }
+
     var message = $"Aarogya alert: emergency contact {contact.Name} was {action}.";
-    var result = await smsSender.SendAsync(patient.Phone, message, "emergency_access", cancellationToken);
+    var result = await smsSender.SendAsync(patient.Phone, message, NotificationEventTypes.EmergencyAccess, cancellationToken);
     if (!result.Success)
     {
       logger.LogWarning(

--- a/src/Aarogya.Api/Features/V1/Notifications/INotificationPreferenceService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/INotificationPreferenceService.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public API controller constructor for dependency injection.")]
+public interface INotificationPreferenceService
+{
+  public Task<NotificationPreferencesResponse> GetForUserAsync(
+    string userSub,
+    CancellationToken cancellationToken = default);
+
+  public Task<NotificationPreferencesResponse> UpdateForUserAsync(
+    string userSub,
+    UpdateNotificationPreferencesRequest request,
+    CancellationToken cancellationToken = default);
+
+  public Task<bool> IsEnabledAsync(
+    string userSub,
+    string eventType,
+    string channel,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/IPushNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/IPushNotificationService.cs
@@ -22,8 +22,18 @@ public interface IPushNotificationService
     string deviceToken,
     CancellationToken cancellationToken = default);
 
+  public Task<NotificationPreferencesResponse> GetPreferencesAsync(
+    string userSub,
+    CancellationToken cancellationToken = default);
+
+  public Task<NotificationPreferencesResponse> UpdatePreferencesAsync(
+    string userSub,
+    UpdateNotificationPreferencesRequest request,
+    CancellationToken cancellationToken = default);
+
   public Task<PushNotificationDeliveryResponse> SendToCurrentUserAsync(
     string userSub,
+    string eventType,
     SendPushNotificationRequest request,
     CancellationToken cancellationToken = default);
 }

--- a/src/Aarogya.Api/Features/V1/Notifications/InMemoryNotificationPreferenceService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/InMemoryNotificationPreferenceService.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using Aarogya.Api.Security;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal sealed class InMemoryNotificationPreferenceService : INotificationPreferenceService
+{
+  private readonly ConcurrentDictionary<string, NotificationPreferencesResponse> _entries = new(StringComparer.Ordinal);
+
+  public Task<NotificationPreferencesResponse> GetForUserAsync(
+    string userSub,
+    CancellationToken cancellationToken = default)
+  {
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    return Task.FromResult(GetOrCreate(normalizedSub));
+  }
+
+  public Task<NotificationPreferencesResponse> UpdateForUserAsync(
+    string userSub,
+    UpdateNotificationPreferencesRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    var updated = new NotificationPreferencesResponse(
+      request.ReportUploaded,
+      request.AccessGranted,
+      request.EmergencyAccess);
+    _entries[normalizedSub] = updated;
+    return Task.FromResult(updated);
+  }
+
+  public Task<bool> IsEnabledAsync(
+    string userSub,
+    string eventType,
+    string channel,
+    CancellationToken cancellationToken = default)
+  {
+    var preferences = GetOrCreate(InputSanitizer.SanitizePlainText(userSub));
+    var eventPreferences = eventType switch
+    {
+      NotificationEventTypes.ReportUploaded => preferences.ReportUploaded,
+      NotificationEventTypes.AccessGranted => preferences.AccessGranted,
+      NotificationEventTypes.EmergencyAccess => preferences.EmergencyAccess,
+      _ => new NotificationChannelPreferences(true, true, true)
+    };
+
+    var enabled = channel switch
+    {
+      NotificationChannels.Push => eventPreferences.Push,
+      NotificationChannels.Email => eventPreferences.Email,
+      NotificationChannels.Sms => eventPreferences.Sms,
+      _ => true
+    };
+
+    return Task.FromResult(enabled);
+  }
+
+  private NotificationPreferencesResponse GetOrCreate(string userSub)
+  {
+    return _entries.GetOrAdd(
+      userSub,
+      static _ => new NotificationPreferencesResponse(
+        ReportUploaded: new NotificationChannelPreferences(Push: true, Email: true, Sms: true),
+        AccessGranted: new NotificationChannelPreferences(Push: true, Email: true, Sms: true),
+        EmergencyAccess: new NotificationChannelPreferences(Push: true, Email: true, Sms: true)));
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/NotificationPreferenceContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/NotificationPreferenceContracts.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Aarogya.Api.Features.V1.Notifications;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public API action signatures.")]
+public sealed record NotificationChannelPreferences(
+  [property: JsonRequired] bool Push,
+  [property: JsonRequired] bool Email,
+  [property: JsonRequired] bool Sms);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public API action signatures.")]
+public sealed record NotificationPreferencesResponse(
+  NotificationChannelPreferences ReportUploaded,
+  NotificationChannelPreferences AccessGranted,
+  NotificationChannelPreferences EmergencyAccess);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public API action signatures.")]
+public sealed record UpdateNotificationPreferencesRequest(
+  [property: JsonRequired] NotificationChannelPreferences ReportUploaded,
+  [property: JsonRequired] NotificationChannelPreferences AccessGranted,
+  [property: JsonRequired] NotificationChannelPreferences EmergencyAccess);

--- a/src/Aarogya.Api/Features/V1/Notifications/NotificationPreferenceKeys.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/NotificationPreferenceKeys.cs
@@ -1,0 +1,15 @@
+namespace Aarogya.Api.Features.V1.Notifications;
+
+internal static class NotificationEventTypes
+{
+  public const string ReportUploaded = "report_uploaded";
+  public const string AccessGranted = "access_granted";
+  public const string EmergencyAccess = "emergency_access";
+}
+
+internal static class NotificationChannels
+{
+  public const string Push = "push";
+  public const string Email = "email";
+  public const string Sms = "sms";
+}

--- a/src/Aarogya.Api/Features/V1/Notifications/PushNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/PushNotificationService.cs
@@ -4,6 +4,7 @@ namespace Aarogya.Api.Features.V1.Notifications;
 
 internal sealed class PushNotificationService(
   IDeviceTokenRegistry tokenRegistry,
+  INotificationPreferenceService preferenceService,
   IPushNotificationSender pushNotificationSender)
   : IPushNotificationService
 {
@@ -22,7 +23,7 @@ internal sealed class PushNotificationService(
   {
     ArgumentNullException.ThrowIfNull(request);
     var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
-    return tokenRegistry.UpsertAsync(normalizedSub, request, cancellationToken);
+    return RegisterDeviceWithDefaultsAsync(normalizedSub, request, cancellationToken);
   }
 
   public Task<bool> DeregisterDeviceAsync(
@@ -35,14 +36,48 @@ internal sealed class PushNotificationService(
     return tokenRegistry.RemoveAsync(normalizedSub, normalizedToken, cancellationToken);
   }
 
+  public Task<NotificationPreferencesResponse> GetPreferencesAsync(
+    string userSub,
+    CancellationToken cancellationToken = default)
+  {
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    return preferenceService.GetForUserAsync(normalizedSub, cancellationToken);
+  }
+
+  public Task<NotificationPreferencesResponse> UpdatePreferencesAsync(
+    string userSub,
+    UpdateNotificationPreferencesRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+    var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    return preferenceService.UpdateForUserAsync(normalizedSub, request, cancellationToken);
+  }
+
   public async Task<PushNotificationDeliveryResponse> SendToCurrentUserAsync(
     string userSub,
+    string eventType,
     SendPushNotificationRequest request,
     CancellationToken cancellationToken = default)
   {
     ArgumentNullException.ThrowIfNull(request);
 
     var normalizedSub = InputSanitizer.SanitizePlainText(userSub);
+    var normalizedEvent = InputSanitizer.SanitizePlainText(eventType);
+    var pushEnabled = await preferenceService.IsEnabledAsync(
+      normalizedSub,
+      normalizedEvent,
+      NotificationChannels.Push,
+      cancellationToken);
+    if (!pushEnabled)
+    {
+      return new PushNotificationDeliveryResponse(
+        RequestedDeviceCount: 0,
+        SuccessCount: 0,
+        FailureCount: 0,
+        SendingEnabled: false);
+    }
+
     var tokens = await tokenRegistry.GetDeviceTokensAsync(normalizedSub, cancellationToken);
     if (tokens.Count == 0)
     {
@@ -54,5 +89,14 @@ internal sealed class PushNotificationService(
     }
 
     return await pushNotificationSender.SendAsync(tokens, request, cancellationToken);
+  }
+
+  private async Task<DeviceTokenRegistrationResponse> RegisterDeviceWithDefaultsAsync(
+    string normalizedSub,
+    RegisterDeviceTokenRequest request,
+    CancellationToken cancellationToken)
+  {
+    _ = await preferenceService.GetForUserAsync(normalizedSub, cancellationToken);
+    return await tokenRegistry.UpsertAsync(normalizedSub, request, cancellationToken);
   }
 }

--- a/src/Aarogya.Api/Features/V1/Notifications/TransactionalEmailNotificationService.cs
+++ b/src/Aarogya.Api/Features/V1/Notifications/TransactionalEmailNotificationService.cs
@@ -5,24 +5,31 @@ namespace Aarogya.Api.Features.V1.Notifications;
 
 internal sealed class TransactionalEmailNotificationService(
   ITransactionalEmailSender emailSender,
+  INotificationPreferenceService preferenceService,
   IOptions<EmailNotificationsOptions> options)
   : ITransactionalEmailNotificationService
 {
   private readonly EmailNotificationsOptions _options = options.Value;
 
-  public Task SendReportUploadedAsync(
+  public async Task SendReportUploadedAsync(
     Domain.Entities.User patient,
     Domain.Entities.Report report,
     CancellationToken cancellationToken = default)
   {
     if (string.IsNullOrWhiteSpace(patient.Email))
     {
-      return Task.CompletedTask;
+      return;
+    }
+
+    var userSub = ResolveUserSub(patient);
+    if (!await preferenceService.IsEnabledAsync(userSub, NotificationEventTypes.ReportUploaded, NotificationChannels.Email, cancellationToken))
+    {
+      return;
     }
 
     var unsubscribeUrl = BuildUnsubscribeUrl(patient.ExternalAuthId, patient.Email);
     var template = TransactionalEmailTemplateBuilder.BuildReportUploaded(patient, report, unsubscribeUrl);
-    return emailSender.SendAsync(
+    await emailSender.SendAsync(
       patient.Email,
       $"{patient.FirstName} {patient.LastName}".Trim(),
       template.Subject,
@@ -31,7 +38,7 @@ internal sealed class TransactionalEmailNotificationService(
       cancellationToken);
   }
 
-  public Task SendAccessGrantedAsync(
+  public async Task SendAccessGrantedAsync(
     Domain.Entities.User patient,
     Domain.Entities.User doctor,
     Domain.Entities.AccessGrant grant,
@@ -39,12 +46,18 @@ internal sealed class TransactionalEmailNotificationService(
   {
     if (string.IsNullOrWhiteSpace(doctor.Email))
     {
-      return Task.CompletedTask;
+      return;
+    }
+
+    var userSub = ResolveUserSub(doctor);
+    if (!await preferenceService.IsEnabledAsync(userSub, NotificationEventTypes.AccessGranted, NotificationChannels.Email, cancellationToken))
+    {
+      return;
     }
 
     var unsubscribeUrl = BuildUnsubscribeUrl(doctor.ExternalAuthId, doctor.Email);
     var template = TransactionalEmailTemplateBuilder.BuildAccessGranted(doctor, patient, grant, unsubscribeUrl);
-    return emailSender.SendAsync(
+    await emailSender.SendAsync(
       doctor.Email,
       $"{doctor.FirstName} {doctor.LastName}".Trim(),
       template.Subject,
@@ -53,7 +66,7 @@ internal sealed class TransactionalEmailNotificationService(
       cancellationToken);
   }
 
-  public Task SendEmergencyAccessEventAsync(
+  public async Task SendEmergencyAccessEventAsync(
     Domain.Entities.User patient,
     Domain.Entities.EmergencyContact contact,
     string action,
@@ -61,12 +74,18 @@ internal sealed class TransactionalEmailNotificationService(
   {
     if (string.IsNullOrWhiteSpace(patient.Email))
     {
-      return Task.CompletedTask;
+      return;
+    }
+
+    var userSub = ResolveUserSub(patient);
+    if (!await preferenceService.IsEnabledAsync(userSub, NotificationEventTypes.EmergencyAccess, NotificationChannels.Email, cancellationToken))
+    {
+      return;
     }
 
     var unsubscribeUrl = BuildUnsubscribeUrl(patient.ExternalAuthId, patient.Email);
     var template = TransactionalEmailTemplateBuilder.BuildEmergencyAccessEvent(patient, contact, action, unsubscribeUrl);
-    return emailSender.SendAsync(
+    await emailSender.SendAsync(
       patient.Email,
       $"{patient.FirstName} {patient.LastName}".Trim(),
       template.Subject,
@@ -81,4 +100,7 @@ internal sealed class TransactionalEmailNotificationService(
     var identity = string.IsNullOrWhiteSpace(userSub) ? email : userSub;
     return $"{baseUrl}?user={Uri.EscapeDataString(identity)}";
   }
+
+  private static string ResolveUserSub(Domain.Entities.User user)
+    => string.IsNullOrWhiteSpace(user.ExternalAuthId) ? user.Id.ToString("D") : user.ExternalAuthId;
 }

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddScoped<IReportChecksumVerificationService, S3ReportChecksumVerificationService>();
     services.AddScoped<IReportVirusScanProcessor, ReportVirusScanProcessor>();
     services.AddSingleton<IReportVirusScanner, ClamAvReportVirusScanner>();
+    services.AddSingleton<INotificationPreferenceService, InMemoryNotificationPreferenceService>();
     services.AddScoped<ITransactionalEmailNotificationService, TransactionalEmailNotificationService>();
     services.AddScoped<ITransactionalEmailSender, SesTransactionalEmailSender>();
     services.AddScoped<ICriticalSmsNotificationService, CriticalSmsNotificationService>();

--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -439,3 +439,13 @@ internal sealed class SendPushNotificationRequestValidator : AbstractValidator<S
       && pair.Value.Length <= 2000);
   }
 }
+
+internal sealed class UpdateNotificationPreferencesRequestValidator : AbstractValidator<UpdateNotificationPreferencesRequest>
+{
+  public UpdateNotificationPreferencesRequestValidator()
+  {
+    RuleFor(x => x.ReportUploaded).NotNull();
+    RuleFor(x => x.AccessGranted).NotNull();
+    RuleFor(x => x.EmergencyAccess).NotNull();
+  }
+}

--- a/tests/Aarogya.Api.Tests/CriticalSmsNotificationServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/CriticalSmsNotificationServiceTests.cs
@@ -1,0 +1,55 @@
+using Aarogya.Api.Features.V1.Notifications;
+using Aarogya.Domain.Entities;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class CriticalSmsNotificationServiceTests
+{
+  [Fact]
+  public async Task SendEmergencyAccessEventAsync_ShouldSkip_WhenSmsPreferenceDisabledAsync()
+  {
+    var sender = new FakeSmsSender();
+    var preferences = new InMemoryNotificationPreferenceService();
+    await preferences.UpdateForUserAsync(
+      "seed-PATIENT-IT",
+      new UpdateNotificationPreferencesRequest(
+        ReportUploaded: new NotificationChannelPreferences(Push: true, Email: true, Sms: true),
+        AccessGranted: new NotificationChannelPreferences(Push: true, Email: true, Sms: true),
+        EmergencyAccess: new NotificationChannelPreferences(Push: true, Email: true, Sms: false)));
+
+    var service = new CriticalSmsNotificationService(sender, preferences, NullLogger<CriticalSmsNotificationService>.Instance);
+    await service.SendEmergencyAccessEventAsync(
+      new User
+      {
+        Id = Guid.NewGuid(),
+        ExternalAuthId = "seed-PATIENT-IT",
+        Phone = "+919876543210"
+      },
+      new EmergencyContact
+      {
+        Id = Guid.NewGuid(),
+        Name = "Kin One"
+      },
+      "created");
+
+    sender.SendCount.Should().Be(0);
+  }
+
+  private sealed class FakeSmsSender : ISmsSender
+  {
+    public int SendCount { get; private set; }
+
+    public Task<SmsSendResult> SendAsync(
+      string phoneNumber,
+      string message,
+      string notificationType,
+      CancellationToken cancellationToken = default)
+    {
+      SendCount++;
+      return Task.FromResult(new SmsSendResult(true, false, 0.25m, "mock-1"));
+    }
+  }
+}

--- a/tests/Aarogya.Api.Tests/NotificationPreferenceServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/NotificationPreferenceServiceTests.cs
@@ -1,0 +1,36 @@
+using Aarogya.Api.Features.V1.Notifications;
+using FluentAssertions;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class NotificationPreferenceServiceTests
+{
+  [Fact]
+  public async Task GetForUserAsync_ShouldReturnEnabledDefaultsAsync()
+  {
+    var service = new InMemoryNotificationPreferenceService();
+
+    var preferences = await service.GetForUserAsync("seed-PATIENT-IT");
+
+    preferences.ReportUploaded.Should().Be(new NotificationChannelPreferences(true, true, true));
+    preferences.AccessGranted.Should().Be(new NotificationChannelPreferences(true, true, true));
+    preferences.EmergencyAccess.Should().Be(new NotificationChannelPreferences(true, true, true));
+  }
+
+  [Fact]
+  public async Task IsEnabledAsync_ShouldReflectUpdatedPreferencesAsync()
+  {
+    var service = new InMemoryNotificationPreferenceService();
+    await service.UpdateForUserAsync(
+      "seed-PATIENT-IT",
+      new UpdateNotificationPreferencesRequest(
+        ReportUploaded: new NotificationChannelPreferences(Push: false, Email: true, Sms: false),
+        AccessGranted: new NotificationChannelPreferences(Push: true, Email: false, Sms: true),
+        EmergencyAccess: new NotificationChannelPreferences(Push: true, Email: true, Sms: false)));
+
+    (await service.IsEnabledAsync("seed-PATIENT-IT", NotificationEventTypes.ReportUploaded, NotificationChannels.Push)).Should().BeFalse();
+    (await service.IsEnabledAsync("seed-PATIENT-IT", NotificationEventTypes.ReportUploaded, NotificationChannels.Email)).Should().BeTrue();
+    (await service.IsEnabledAsync("seed-PATIENT-IT", NotificationEventTypes.EmergencyAccess, NotificationChannels.Sms)).Should().BeFalse();
+  }
+}

--- a/tests/Aarogya.Api.Tests/NotificationsControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/NotificationsControllerTests.cs
@@ -24,6 +24,60 @@ public sealed class NotificationsControllerTests
   }
 
   [Fact]
+  public async Task GetPreferencesAsync_ShouldReturnUnauthorized_WhenSubjectMissingAsync()
+  {
+    var controller = CreateController(Mock.Of<IPushNotificationService>(), new ClaimsPrincipal(new ClaimsIdentity()));
+
+    var result = await controller.GetPreferencesAsync(CancellationToken.None);
+
+    result.Should().BeOfType<UnauthorizedResult>();
+  }
+
+  [Fact]
+  public async Task GetPreferencesAsync_ShouldReturnOk_WhenAuthenticatedAsync()
+  {
+    var service = new Mock<IPushNotificationService>();
+    var response = new NotificationPreferencesResponse(
+      new NotificationChannelPreferences(true, true, true),
+      new NotificationChannelPreferences(true, false, false),
+      new NotificationChannelPreferences(true, true, false));
+    service
+      .Setup(x => x.GetPreferencesAsync("seed-PATIENT-IT", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(response);
+
+    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-IT"));
+
+    var result = await controller.GetPreferencesAsync(CancellationToken.None);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    ok.Value.Should().BeEquivalentTo(response);
+  }
+
+  [Fact]
+  public async Task UpdatePreferencesAsync_ShouldReturnOk_WhenAuthenticatedAsync()
+  {
+    var service = new Mock<IPushNotificationService>();
+    var request = new UpdateNotificationPreferencesRequest(
+      new NotificationChannelPreferences(true, true, true),
+      new NotificationChannelPreferences(true, false, false),
+      new NotificationChannelPreferences(true, true, false));
+    var response = new NotificationPreferencesResponse(
+      new NotificationChannelPreferences(true, true, true),
+      new NotificationChannelPreferences(true, false, false),
+      new NotificationChannelPreferences(true, true, false));
+    service
+      .Setup(x => x.UpdatePreferencesAsync("seed-PATIENT-IT", request, It.IsAny<CancellationToken>()))
+      .ReturnsAsync(response);
+
+    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-IT"));
+
+    var result = await controller.UpdatePreferencesAsync(request, CancellationToken.None);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    ok.Value.Should().BeEquivalentTo(response);
+  }
+
+  [Fact]
   public async Task RegisterDeviceAsync_ShouldReturnCreated_WhenValidAsync()
   {
     var service = new Mock<IPushNotificationService>();
@@ -55,13 +109,18 @@ public sealed class NotificationsControllerTests
     var service = new Mock<IPushNotificationService>();
     var response = new PushNotificationDeliveryResponse(1, 1, 0, true);
     service
-      .Setup(x => x.SendToCurrentUserAsync("seed-PATIENT-IT", It.IsAny<SendPushNotificationRequest>(), It.IsAny<CancellationToken>()))
+      .Setup(x => x.SendToCurrentUserAsync(
+        "seed-PATIENT-IT",
+        NotificationEventTypes.ReportUploaded,
+        It.IsAny<SendPushNotificationRequest>(),
+        It.IsAny<CancellationToken>()))
       .ReturnsAsync(response);
 
     var controller = CreateController(service.Object, CreateUser("seed-PATIENT-IT"));
 
     var result = await controller.SendTestNotificationAsync(
       new SendPushNotificationRequest("Test", "Body"),
+      NotificationEventTypes.ReportUploaded,
       CancellationToken.None);
 
     var ok = result.Should().BeOfType<OkObjectResult>().Subject;

--- a/tests/Aarogya.Api.Tests/PushNotificationServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/PushNotificationServiceTests.cs
@@ -11,7 +11,8 @@ public sealed class PushNotificationServiceTests
   public async Task RegisterDeviceAsync_ShouldPersistAndListRegistrationAsync()
   {
     var registry = new InMemoryDeviceTokenRegistry(new SystemUtcClock());
-    var service = new PushNotificationService(registry, new FakePushNotificationSender());
+    var preferences = new InMemoryNotificationPreferenceService();
+    var service = new PushNotificationService(registry, preferences, new FakePushNotificationSender());
 
     var registration = await service.RegisterDeviceAsync(
       "seed-PATIENT-IT",
@@ -28,7 +29,8 @@ public sealed class PushNotificationServiceTests
   public async Task DeregisterDeviceAsync_ShouldReturnFalse_WhenTokenMissingAsync()
   {
     var registry = new InMemoryDeviceTokenRegistry(new SystemUtcClock());
-    var service = new PushNotificationService(registry, new FakePushNotificationSender());
+    var preferences = new InMemoryNotificationPreferenceService();
+    var service = new PushNotificationService(registry, preferences, new FakePushNotificationSender());
 
     var removed = await service.DeregisterDeviceAsync("seed-PATIENT-IT", "missing-token");
 
@@ -39,19 +41,46 @@ public sealed class PushNotificationServiceTests
   public async Task SendToCurrentUserAsync_ShouldSendToRegisteredTokensAsync()
   {
     var registry = new InMemoryDeviceTokenRegistry(new SystemUtcClock());
+    var preferences = new InMemoryNotificationPreferenceService();
     var sender = new FakePushNotificationSender();
 
-    var service = new PushNotificationService(registry, sender);
+    var service = new PushNotificationService(registry, preferences, sender);
     await service.RegisterDeviceAsync("seed-PATIENT-IT", new RegisterDeviceTokenRequest("token-1", "ios"));
     await service.RegisterDeviceAsync("seed-PATIENT-IT", new RegisterDeviceTokenRequest("token-2", "android"));
 
     var result = await service.SendToCurrentUserAsync(
       "seed-PATIENT-IT",
+      NotificationEventTypes.ReportUploaded,
       new SendPushNotificationRequest("Lab Report Ready", "Your report is now available."));
 
     result.SuccessCount.Should().Be(2);
     sender.LastTokens.Should().Contain(["token-1", "token-2"]);
     sender.InvocationCount.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task SendToCurrentUserAsync_ShouldRespectDisabledPushPreferenceAsync()
+  {
+    var registry = new InMemoryDeviceTokenRegistry(new SystemUtcClock());
+    var preferences = new InMemoryNotificationPreferenceService();
+    var sender = new FakePushNotificationSender();
+    var service = new PushNotificationService(registry, preferences, sender);
+
+    await service.RegisterDeviceAsync("seed-PATIENT-IT", new RegisterDeviceTokenRequest("token-1", "ios"));
+    await service.UpdatePreferencesAsync(
+      "seed-PATIENT-IT",
+      new UpdateNotificationPreferencesRequest(
+        ReportUploaded: new NotificationChannelPreferences(Push: false, Email: true, Sms: true),
+        AccessGranted: new NotificationChannelPreferences(Push: true, Email: true, Sms: true),
+        EmergencyAccess: new NotificationChannelPreferences(Push: true, Email: true, Sms: true)));
+
+    var result = await service.SendToCurrentUserAsync(
+      "seed-PATIENT-IT",
+      NotificationEventTypes.ReportUploaded,
+      new SendPushNotificationRequest("Lab Report Ready", "Your report is now available."));
+
+    result.SendingEnabled.Should().BeFalse();
+    sender.InvocationCount.Should().Be(0);
   }
 
   private sealed class FakePushNotificationSender : IPushNotificationSender

--- a/tests/Aarogya.Api.Tests/TransactionalEmailNotificationServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/TransactionalEmailNotificationServiceTests.cs
@@ -1,0 +1,67 @@
+using Aarogya.Api.Configuration;
+using Aarogya.Api.Features.V1.Notifications;
+using Aarogya.Domain.Entities;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class TransactionalEmailNotificationServiceTests
+{
+  [Fact]
+  public async Task SendReportUploadedAsync_ShouldSkip_WhenEmailPreferenceDisabledAsync()
+  {
+    var sender = new FakeTransactionalEmailSender();
+    var preferences = new InMemoryNotificationPreferenceService();
+    await preferences.UpdateForUserAsync(
+      "seed-PATIENT-IT",
+      new UpdateNotificationPreferencesRequest(
+        ReportUploaded: new NotificationChannelPreferences(Push: true, Email: false, Sms: true),
+        AccessGranted: new NotificationChannelPreferences(Push: true, Email: true, Sms: true),
+        EmergencyAccess: new NotificationChannelPreferences(Push: true, Email: true, Sms: true)));
+
+    var service = new TransactionalEmailNotificationService(
+      sender,
+      preferences,
+      Options.Create(new EmailNotificationsOptions
+      {
+        EnableTransactionalEmails = true,
+        UnsubscribeBaseUrl = "https://aarogya.app/unsubscribe"
+      }));
+
+    await service.SendReportUploadedAsync(
+      new User
+      {
+        Id = Guid.NewGuid(),
+        ExternalAuthId = "seed-PATIENT-IT",
+        FirstName = "Test",
+        LastName = "User",
+        Email = "patient@example.com"
+      },
+      new Report
+      {
+        Id = Guid.NewGuid(),
+        ReportNumber = "REP-123"
+      });
+
+    sender.SendCount.Should().Be(0);
+  }
+
+  private sealed class FakeTransactionalEmailSender : ITransactionalEmailSender
+  {
+    public int SendCount { get; private set; }
+
+    public Task SendAsync(
+      string toEmail,
+      string? toName,
+      string subject,
+      string htmlBody,
+      string textBody,
+      CancellationToken cancellationToken = default)
+    {
+      SendCount++;
+      return Task.CompletedTask;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add per-user notification preferences for report uploaded, access granted, and emergency access events
- expose preference management APIs: GET/PUT /api/v1/notifications/preferences
- enforce preferences in push, transactional email, and critical SMS notification services
- create default all-enabled preferences on first user interaction (including device registration)
- add validators, tests, and README updates

## Validation
- dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations
- dotnet test Aarogya.sln

## Notes
- Sonar can be ignored for gating per request