### PR TITLE
feat: implement response caching with etag for report listings

### DIFF
--- a/src/Aarogya.Api/Controllers/V1/ReportsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/ReportsController.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
 using Aarogya.Api.Authorization;
 using Aarogya.Api.Features.V1.Common;
 using Aarogya.Api.Features.V1.Consents;
@@ -8,6 +10,7 @@ using Aarogya.Api.Validation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Net.Http.Headers;
 
 namespace Aarogya.Api.Controllers.V1;
 
@@ -25,6 +28,8 @@ namespace Aarogya.Api.Controllers.V1;
   Justification = "This controller groups related report operations intentionally to keep route discovery cohesive.")]
 public sealed class ReportsController : ControllerBase
 {
+  private const string ReportListCacheControlValue = "private, max-age=30, must-revalidate";
+
   private readonly IReportService _reportService;
   private readonly IReportFileUploadService _reportFileUploadService;
   private readonly IReportChecksumVerificationService _reportChecksumVerificationService;
@@ -109,6 +114,14 @@ public sealed class ReportsController : ControllerBase
     {
       await _consentService.EnsureGrantedAsync(userSub, ConsentPurposeCatalog.MedicalRecordsProcessing, cancellationToken);
       var result = await _reportService.GetForUserAsync(userSub, request, cancellationToken);
+      var etag = BuildReportListEtag(userSub, request, result);
+      SetReportListCachingHeaders(etag);
+
+      if (MatchesIfNoneMatch(etag))
+      {
+        return StatusCode(StatusCodes.Status304NotModified);
+      }
+
       return Ok(result);
     }
     catch (ConsentRequiredException ex)
@@ -361,5 +374,74 @@ public sealed class ReportsController : ControllerBase
         {
           ["consent"] = [$"Consent for purpose '{purpose}' is required."]
         }));
+  }
+
+  private void SetReportListCachingHeaders(string etag)
+  {
+    Response.Headers[HeaderNames.ETag] = etag;
+    Response.Headers[HeaderNames.CacheControl] = ReportListCacheControlValue;
+    Response.Headers[HeaderNames.Vary] = HeaderNames.Authorization;
+  }
+
+  private bool MatchesIfNoneMatch(string etag)
+  {
+    if (!Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var values))
+    {
+      return false;
+    }
+
+    foreach (var rawValue in values)
+    {
+      if (string.IsNullOrWhiteSpace(rawValue))
+      {
+        continue;
+      }
+
+      if (string.Equals(rawValue.Trim(), "*", StringComparison.Ordinal))
+      {
+        return true;
+      }
+
+      foreach (var token in rawValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+      {
+        var normalized = token.StartsWith("W/", StringComparison.OrdinalIgnoreCase)
+          ? token[2..].Trim()
+          : token.Trim();
+        if (string.Equals(normalized, etag, StringComparison.Ordinal))
+        {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private static string BuildReportListEtag(
+    string userSub,
+    ReportListQueryRequest request,
+    ReportListResponse response)
+  {
+    var builder = new StringBuilder();
+    builder.Append(userSub);
+    builder.Append('|').Append(request.ReportType);
+    builder.Append('|').Append(request.Status);
+    builder.Append('|').Append(request.FromDate?.ToUniversalTime().ToString("O"));
+    builder.Append('|').Append(request.ToDate?.ToUniversalTime().ToString("O"));
+    builder.Append('|').Append(response.Page);
+    builder.Append('|').Append(response.PageSize);
+    builder.Append('|').Append(response.TotalCount);
+
+    foreach (var item in response.Items)
+    {
+      builder.Append('|').Append(item.ReportId.ToString("D"));
+      builder.Append('|').Append(item.Title);
+      builder.Append('|').Append(item.Status);
+      builder.Append('|').Append(item.CreatedAt.ToUniversalTime().ToString("O"));
+    }
+
+    var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+    var hash = Convert.ToHexString(hashBytes);
+    return $"\"{hash}\"";
   }
 }

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -162,6 +162,7 @@ builder.Services.Configure<Microsoft.AspNetCore.Http.Features.FormOptions>(optio
 builder.Services.AddFluentValidationAutoValidation();
 builder.Services.AddValidatorsFromAssemblyContaining<OtpRequestCommandValidator>(includeInternalTypes: true);
 builder.Services.AddMemoryCache();
+builder.Services.AddResponseCaching();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddHttpClient(CognitoOAuthTokenClient.HttpClientName, client =>
@@ -262,6 +263,7 @@ if (!app.Environment.IsDevelopment())
   app.UseHsts();
 }
 app.UseCors("AarogyaPolicy");
+app.UseResponseCaching();
 app.UseAuthentication();
 if (rateLimitingOptions.EnableRateLimiting)
 {

--- a/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
@@ -6,6 +6,7 @@ using Aarogya.Api.Validation;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
@@ -113,6 +114,49 @@ public sealed class ReportsControllerTests
 
     var ok = result.Should().BeOfType<OkObjectResult>().Subject;
     ok.Value.Should().BeEquivalentTo(expected);
+    controller.Response.Headers[HeaderNames.ETag].ToString().Should().NotBeNullOrWhiteSpace();
+    controller.Response.Headers[HeaderNames.CacheControl].ToString().Should().Contain("private");
+  }
+
+  [Fact]
+  public async Task ListReportsAsync_ShouldReturnNotModified_WhenIfNoneMatchMatchesAsync()
+  {
+    var expected = new ReportListResponse(
+      Page: 1,
+      PageSize: 20,
+      TotalCount: 1,
+      Items:
+      [
+        new ReportSummaryResponse(
+          Guid.NewGuid(),
+          "blood_test - Aarogya Diagnostics",
+          "uploaded",
+          new DateTimeOffset(2026, 2, 20, 0, 0, 0, TimeSpan.Zero))
+      ]);
+
+    var reportService = new Mock<IReportService>();
+    reportService
+      .Setup(x => x.GetForUserAsync("seed-PATIENT-1", It.IsAny<ReportListQueryRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(expected);
+
+    var controller = CreateController(
+      user: CreateUser("seed-PATIENT-1"),
+      uploadService: Mock.Of<IReportFileUploadService>(),
+      reportService: reportService.Object,
+      checksumService: Mock.Of<IReportChecksumVerificationService>());
+
+    _ = await controller.ListReportsAsync(new ReportListQueryRequest(), CancellationToken.None);
+    var etag = controller.Response.Headers[HeaderNames.ETag].ToString();
+    etag.Should().NotBeNullOrWhiteSpace();
+
+    controller.Response.Headers.Clear();
+    controller.Request.Headers[HeaderNames.IfNoneMatch] = etag;
+
+    var secondResult = await controller.ListReportsAsync(new ReportListQueryRequest(), CancellationToken.None);
+
+    var status = secondResult.Should().BeOfType<StatusCodeResult>().Subject;
+    status.StatusCode.Should().Be(StatusCodes.Status304NotModified);
+    controller.Response.Headers[HeaderNames.ETag].ToString().Should().Be(etag);
   }
 
   [Fact]


### PR DESCRIPTION
## Summary
- add HTTP response caching behavior for report listing responses
- add ETag generation and conditional request handling (`If-None-Match` -> `304 Not Modified`)
- set explicit cache headers for safe private caching

## Implementation
- `GET /api/v1/reports` now:
  - computes deterministic ETag from user/query/result payload shape
  - emits `ETag`, `Cache-Control: private, max-age=30, must-revalidate`, and `Vary: Authorization`
  - returns `304 Not Modified` when `If-None-Match` matches current ETag
- enabled ASP.NET Core response-caching middleware in app pipeline
- added controller tests for:
  - cache header emission on list response
  - conditional request `304` behavior

## Validation
- `dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations`
- `dotnet test Aarogya.sln`

Closes #69
