### PR TITLE
feat: implement issue #71 data export and right to erasure

### DIFF
--- a/src/Aarogya.Api/Controllers/V1/UsersController.cs
+++ b/src/Aarogya.Api/Controllers/V1/UsersController.cs
@@ -21,6 +21,7 @@ namespace Aarogya.Api.Controllers.V1;
   Justification = "ASP.NET Core controllers must be public to be discovered by the framework.")]
 public sealed class UsersController(
   IUserProfileService userProfileService,
+  IUserDataRightsService userDataRightsService,
   IConsentService consentService)
   : ControllerBase
 {
@@ -138,6 +139,86 @@ public sealed class UsersController(
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
         {
           ["user"] = [ex.Message]
+        }));
+    }
+  }
+
+  [HttpGet("me/export")]
+  [ProducesResponseType(typeof(DataExportResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status403Forbidden)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<IActionResult> ExportCurrentUserDataAsync(CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    try
+    {
+      await consentService.EnsureGrantedAsync(userSub, ConsentPurposeCatalog.ProfileManagement, cancellationToken);
+      var payload = await userDataRightsService.ExportCurrentUserDataAsync(userSub, cancellationToken);
+      return Ok(payload);
+    }
+    catch (ConsentRequiredException ex)
+    {
+      return ForbidWithConsentError(ex.Purpose);
+    }
+    catch (KeyNotFoundException ex)
+    {
+      return NotFound(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["user"] = [ex.Message]
+        }));
+    }
+  }
+
+  [HttpPost("me/deletion")]
+  [ProducesResponseType(typeof(DataDeletionResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status403Forbidden)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<IActionResult> DeleteCurrentUserDataAsync(
+    [FromBody] DataDeletionRequest request,
+    CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    try
+    {
+      await consentService.EnsureGrantedAsync(userSub, ConsentPurposeCatalog.ProfileManagement, cancellationToken);
+      var response = await userDataRightsService.DeleteCurrentUserDataAsync(userSub, request, cancellationToken);
+      return Ok(response);
+    }
+    catch (ConsentRequiredException ex)
+    {
+      return ForbidWithConsentError(ex.Purpose);
+    }
+    catch (KeyNotFoundException ex)
+    {
+      return NotFound(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["user"] = [ex.Message]
+        }));
+    }
+    catch (InvalidOperationException ex)
+    {
+      return BadRequest(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["deletion"] = [ex.Message]
         }));
     }
   }

--- a/src/Aarogya.Api/Features/V1/Users/IUserDataRightsService.cs
+++ b/src/Aarogya.Api/Features/V1/Users/IUserDataRightsService.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aarogya.Api.Features.V1.Users;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public controller constructor injection.")]
+public interface IUserDataRightsService
+{
+  public Task<DataExportResponse> ExportCurrentUserDataAsync(
+    string userSub,
+    CancellationToken cancellationToken = default);
+
+  public Task<DataDeletionResponse> DeleteCurrentUserDataAsync(
+    string userSub,
+    DataDeletionRequest request,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Users/UserDataRightsContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Users/UserDataRightsContracts.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace Aarogya.Api.Features.V1.Users;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record DataExportResponse(
+  DateTimeOffset GeneratedAtUtc,
+  UserProfileExportData Profile,
+  IReadOnlyList<ReportExportData> Reports,
+  IReadOnlyList<AccessGrantExportData> AccessGrants,
+  IReadOnlyList<EmergencyContactExportData> EmergencyContacts,
+  IReadOnlyList<ConsentRecordExportData> Consents,
+  IReadOnlyList<AuditLogExportData> AuditLogs);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record UserProfileExportData(
+  Guid UserId,
+  string? Sub,
+  string Email,
+  string FirstName,
+  string LastName,
+  string? Phone,
+  string? Address,
+  string? BloodGroup,
+  DateOnly? DateOfBirth,
+  bool IsActive,
+  string Role);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record ReportExportData(
+  Guid ReportId,
+  string ReportNumber,
+  string ReportType,
+  string Status,
+  DateTimeOffset UploadedAt,
+  string? SourceSystem,
+  bool IsDeleted);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record AccessGrantExportData(
+  Guid GrantId,
+  Guid PatientUserId,
+  Guid GrantedToUserId,
+  Guid GrantedByUserId,
+  string Status,
+  string? Purpose,
+  DateTimeOffset StartsAt,
+  DateTimeOffset? ExpiresAt,
+  DateTimeOffset? RevokedAt);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record EmergencyContactExportData(
+  Guid EmergencyContactId,
+  string Name,
+  string Relationship,
+  string Phone,
+  string? Email,
+  bool IsPrimary,
+  DateTimeOffset CreatedAt);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record ConsentRecordExportData(
+  Guid ConsentRecordId,
+  string Purpose,
+  bool IsGranted,
+  string Source,
+  DateTimeOffset OccurredAt);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record AuditLogExportData(
+  Guid AuditLogId,
+  DateTimeOffset OccurredAt,
+  string Action,
+  string EntityType,
+  Guid? EntityId,
+  int? ResultStatus);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record DataDeletionRequest(
+  [property: JsonRequired] bool ConfirmPermanentDeletion,
+  string? Reason = null);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by API action signatures.")]
+public sealed record DataDeletionResponse(
+  DateTimeOffset DeletedAtUtc,
+  IReadOnlyDictionary<string, int> AffectedRecords,
+  IReadOnlyList<string> RetentionExceptions);

--- a/src/Aarogya.Api/Features/V1/Users/UserDataRightsService.cs
+++ b/src/Aarogya.Api/Features/V1/Users/UserDataRightsService.cs
@@ -1,0 +1,252 @@
+using System.Globalization;
+using Aarogya.Api.Auditing;
+using Aarogya.Api.Authentication;
+using Aarogya.Api.Security;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+
+namespace Aarogya.Api.Features.V1.Users;
+
+internal sealed class UserDataRightsService(
+  IUserRepository userRepository,
+  IReportRepository reportRepository,
+  IAccessGrantRepository accessGrantRepository,
+  IEmergencyContactRepository emergencyContactRepository,
+  IConsentRecordRepository consentRecordRepository,
+  IAuditLogRepository auditLogRepository,
+  IUnitOfWork unitOfWork,
+  IAuditLoggingService auditLoggingService,
+  IUtcClock clock)
+  : IUserDataRightsService
+{
+  private static readonly IReadOnlyList<string> DeletionRetentionExceptions =
+  [
+    "Anonymized audit logs are retained for security and legal compliance."
+  ];
+
+  public async Task<DataExportResponse> ExportCurrentUserDataAsync(
+    string userSub,
+    CancellationToken cancellationToken = default)
+  {
+    var user = await ResolveUserAsync(userSub, cancellationToken);
+
+    var reports = await reportRepository.ListAsync(new ReportsByRelatedUserSpecification(user.Id, includeDeleted: true), cancellationToken);
+    var grants = await accessGrantRepository.ListAsync(new AccessGrantsByUserSpecification(user.Id), cancellationToken);
+    var emergencyContacts = await emergencyContactRepository.ListByUserAsync(user.Id, cancellationToken);
+    var consents = await consentRecordRepository.ListAsync(new ConsentRecordsByUserSpecification(user.Id), cancellationToken);
+    var auditLogs = await auditLogRepository.ListByActorAsync(user.Id, cancellationToken);
+
+    var response = new DataExportResponse(
+      clock.UtcNow,
+      new UserProfileExportData(
+        user.Id,
+        user.ExternalAuthId,
+        user.Email,
+        user.FirstName,
+        user.LastName,
+        user.Phone,
+        user.Address,
+        user.BloodGroup,
+        user.DateOfBirth,
+        user.IsActive,
+        user.Role.ToString()),
+      reports.Select(report => new ReportExportData(
+        report.Id,
+        report.ReportNumber,
+        report.ReportType.ToString(),
+        report.Status.ToString(),
+        report.UploadedAt,
+        report.SourceSystem,
+        report.IsDeleted)).ToArray(),
+      grants.Select(grant => new AccessGrantExportData(
+        grant.Id,
+        grant.PatientId,
+        grant.GrantedToUserId,
+        grant.GrantedByUserId,
+        grant.Status.ToString(),
+        grant.GrantReason,
+        grant.StartsAt,
+        grant.ExpiresAt,
+        grant.RevokedAt)).ToArray(),
+      emergencyContacts.Select(contact => new EmergencyContactExportData(
+        contact.Id,
+        contact.Name,
+        contact.Relationship,
+        contact.Phone,
+        contact.Email,
+        contact.IsPrimary,
+        contact.CreatedAt)).ToArray(),
+      consents.Select(record => new ConsentRecordExportData(
+        record.Id,
+        record.Purpose,
+        record.IsGranted,
+        record.Source,
+        record.OccurredAt)).ToArray(),
+      auditLogs.Select(log => new AuditLogExportData(
+        log.Id,
+        log.OccurredAt,
+        log.Action,
+        log.EntityType,
+        log.EntityId,
+        log.ResultStatus)).ToArray());
+
+    await auditLoggingService.LogDataAccessAsync(
+      user,
+      "user_data.export_requested",
+      "user",
+      user.Id,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["reportsCount"] = response.Reports.Count.ToString(CultureInfo.InvariantCulture),
+        ["accessGrantsCount"] = response.AccessGrants.Count.ToString(CultureInfo.InvariantCulture)
+      },
+      cancellationToken);
+
+    return response;
+  }
+
+  public async Task<DataDeletionResponse> DeleteCurrentUserDataAsync(
+    string userSub,
+    DataDeletionRequest request,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(request);
+    if (!request.ConfirmPermanentDeletion)
+    {
+      throw new InvalidOperationException("ConfirmPermanentDeletion must be true to proceed.");
+    }
+
+    var user = await ResolveUserAsync(userSub, cancellationToken);
+    var now = clock.UtcNow;
+
+    var reports = await reportRepository.ListAsync(new ReportsByRelatedUserSpecification(user.Id, includeDeleted: true), cancellationToken);
+    var grants = await accessGrantRepository.ListAsync(new AccessGrantsByUserSpecification(user.Id), cancellationToken);
+    var contacts = await emergencyContactRepository.ListByUserAsync(user.Id, cancellationToken);
+    var consents = await consentRecordRepository.ListAsync(new ConsentRecordsByUserSpecification(user.Id), cancellationToken);
+    var auditLogs = await auditLogRepository.ListByActorAsync(user.Id, cancellationToken);
+
+    foreach (var report in reports)
+    {
+      report.Results.Notes = null;
+      report.Results.Parameters = [];
+      report.Metadata.Tags.Clear();
+      report.Parameters.Clear();
+      report.FileStorageKey = null;
+      report.ChecksumSha256 = null;
+      report.IsDeleted = true;
+      report.DeletedAt = now;
+      report.HardDeletedAt = now;
+      report.UpdatedAt = now;
+      reportRepository.Update(report);
+    }
+
+    foreach (var grant in grants)
+    {
+      accessGrantRepository.Delete(grant);
+    }
+
+    foreach (var contact in contacts)
+    {
+      emergencyContactRepository.Delete(contact);
+    }
+
+    foreach (var consent in consents)
+    {
+      consentRecordRepository.Delete(consent);
+    }
+
+    foreach (var auditLog in auditLogs)
+    {
+      auditLog.ActorUserId = null;
+      auditLog.UserAgent = null;
+      auditLog.ClientIp = null;
+      auditLog.Details.Summary = "Anonymized after user deletion request.";
+      auditLog.Details.Data = RedactAuditData(auditLog.Details.Data);
+      auditLogRepository.Update(auditLog);
+    }
+
+    AnonymizeUser(user, now);
+    userRepository.Update(user);
+    await unitOfWork.SaveChangesAsync(cancellationToken);
+
+    await auditLoggingService.LogDataAccessAsync(
+      user,
+      "user_data.deletion_requested",
+      "user",
+      user.Id,
+      200,
+      new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["reason"] = InputSanitizer.SanitizeNullablePlainText(request.Reason) ?? string.Empty,
+        ["reportsAffected"] = reports.Count.ToString(CultureInfo.InvariantCulture),
+        ["accessGrantsAffected"] = grants.Count.ToString(CultureInfo.InvariantCulture)
+      },
+      cancellationToken);
+
+    return new DataDeletionResponse(
+      now,
+      new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+      {
+        ["reports"] = reports.Count,
+        ["accessGrants"] = grants.Count,
+        ["emergencyContacts"] = contacts.Count,
+        ["consentRecords"] = consents.Count,
+        ["auditLogsAnonymized"] = auditLogs.Count,
+        ["users"] = 1
+      },
+      DeletionRetentionExceptions);
+  }
+
+  private async Task<User> ResolveUserAsync(string userSub, CancellationToken cancellationToken)
+  {
+    return await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken)
+      ?? throw new KeyNotFoundException("Authenticated user is not provisioned in the database.");
+  }
+
+  private static void AnonymizeUser(User user, DateTimeOffset now)
+  {
+    user.ExternalAuthId = null;
+    user.FirstName = "Deleted";
+    user.LastName = "User";
+    user.Email = $"deleted-{user.Id:D}@deleted.local";
+    user.Phone = null;
+    user.Address = null;
+    user.BloodGroup = null;
+    user.DateOfBirth = null;
+    user.EmailHash = null;
+    user.PhoneHash = null;
+    user.AadhaarRefToken = null;
+    user.AadhaarSha256 = null;
+    user.IsActive = false;
+    user.UpdatedAt = now;
+  }
+
+  private static Dictionary<string, string> RedactAuditData(IReadOnlyDictionary<string, string>? source)
+  {
+    if (source is null || source.Count == 0)
+    {
+      return [];
+    }
+
+    var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var (key, value) in source)
+    {
+      if (key.Contains("email", StringComparison.OrdinalIgnoreCase)
+        || key.Contains("phone", StringComparison.OrdinalIgnoreCase)
+        || key.Contains("aadhaar", StringComparison.OrdinalIgnoreCase)
+        || key.Contains("address", StringComparison.OrdinalIgnoreCase)
+        || key.Contains("name", StringComparison.OrdinalIgnoreCase))
+      {
+        result[key] = "[REDACTED]";
+      }
+      else
+      {
+        result[key] = value;
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddSingleton<IEntityCacheService, DistributedEntityCacheService>();
     services.AddScoped<UserProfileService>();
     services.AddScoped<IUserProfileService, CachedUserProfileService>();
+    services.AddScoped<IUserDataRightsService, UserDataRightsService>();
     services.AddScoped<ReportService>();
     services.AddScoped<IReportService, CachedReportService>();
     services.AddScoped<ICloudFrontInvalidationService, CloudFrontInvalidationService>();

--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -397,6 +397,20 @@ internal sealed class UpdateUserProfileRequestValidator : AbstractValidator<Upda
   }
 }
 
+internal sealed class DataDeletionRequestValidator : AbstractValidator<DataDeletionRequest>
+{
+  public DataDeletionRequestValidator()
+  {
+    RuleFor(x => x.ConfirmPermanentDeletion)
+      .Equal(true)
+      .WithMessage("ConfirmPermanentDeletion must be true to proceed.");
+
+    RuleFor(x => x.Reason)
+      .MaximumLength(500)
+      .When(x => x.Reason is not null);
+  }
+}
+
 internal sealed class RegisterDeviceTokenRequestValidator : AbstractValidator<RegisterDeviceTokenRequest>
 {
   private static readonly string[] SupportedPlatforms = ["ios", "android"];

--- a/src/Aarogya.Domain/Specifications/AccessGrantsByUserSpecification.cs
+++ b/src/Aarogya.Domain/Specifications/AccessGrantsByUserSpecification.cs
@@ -1,0 +1,15 @@
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Domain.Specifications;
+
+public sealed class AccessGrantsByUserSpecification : BaseSpecification<AccessGrant>
+{
+  public AccessGrantsByUserSpecification(Guid userId)
+    : base(grant =>
+      grant.PatientId == userId
+      || grant.GrantedToUserId == userId
+      || grant.GrantedByUserId == userId)
+  {
+    ApplyOrderByDescending(grant => grant.CreatedAt);
+  }
+}

--- a/src/Aarogya.Domain/Specifications/ConsentRecordsByUserSpecification.cs
+++ b/src/Aarogya.Domain/Specifications/ConsentRecordsByUserSpecification.cs
@@ -1,0 +1,12 @@
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Domain.Specifications;
+
+public sealed class ConsentRecordsByUserSpecification : BaseSpecification<ConsentRecord>
+{
+  public ConsentRecordsByUserSpecification(Guid userId)
+    : base(record => record.UserId == userId)
+  {
+    ApplyOrderByDescending(record => record.OccurredAt);
+  }
+}

--- a/src/Aarogya.Domain/Specifications/ReportsByRelatedUserSpecification.cs
+++ b/src/Aarogya.Domain/Specifications/ReportsByRelatedUserSpecification.cs
@@ -1,0 +1,17 @@
+using Aarogya.Domain.Entities;
+
+namespace Aarogya.Domain.Specifications;
+
+public sealed class ReportsByRelatedUserSpecification : BaseSpecification<Report>
+{
+  public ReportsByRelatedUserSpecification(Guid userId, bool includeDeleted = false)
+    : base(report =>
+      (report.PatientId == userId
+       || report.UploadedByUserId == userId
+       || report.DoctorId == userId)
+      && (includeDeleted || !report.IsDeleted))
+  {
+    AddInclude(report => report.Parameters);
+    ApplyOrderByDescending(report => report.UploadedAt);
+  }
+}

--- a/tests/Aarogya.Api.Tests/UserDataRightsServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/UserDataRightsServiceTests.cs
@@ -1,0 +1,315 @@
+using Aarogya.Api.Auditing;
+using Aarogya.Api.Authentication;
+using Aarogya.Api.Features.V1.Users;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+using Aarogya.Domain.ValueObjects;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class UserDataRightsServiceTests
+{
+  [Fact]
+  public async Task ExportCurrentUserDataAsync_ShouldReturnPortablePayloadAndLogRequestAsync()
+  {
+    var user = CreateUser("seed-PATIENT-1");
+    var report = new Report
+    {
+      Id = Guid.NewGuid(),
+      PatientId = user.Id,
+      UploadedByUserId = user.Id,
+      ReportNumber = "RPT-001",
+      ReportType = ReportType.BloodTest,
+      Status = ReportStatus.Published,
+      UploadedAt = new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)
+    };
+
+    var accessGrant = new AccessGrant
+    {
+      Id = Guid.NewGuid(),
+      PatientId = user.Id,
+      GrantedByUserId = user.Id,
+      GrantedToUserId = Guid.NewGuid(),
+      Status = AccessGrantStatus.Active,
+      StartsAt = new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)
+    };
+
+    var emergencyContact = new EmergencyContact
+    {
+      Id = Guid.NewGuid(),
+      UserId = user.Id,
+      Name = "Primary Contact",
+      Relationship = "Father",
+      Phone = "+919900001111",
+      CreatedAt = new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)
+    };
+
+    var consent = new ConsentRecord
+    {
+      Id = Guid.NewGuid(),
+      UserId = user.Id,
+      Purpose = "reports.share",
+      IsGranted = true,
+      Source = "api",
+      OccurredAt = new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)
+    };
+
+    var auditLog = new AuditLog
+    {
+      Id = Guid.NewGuid(),
+      ActorUserId = user.Id,
+      Action = "reports.created",
+      EntityType = "report",
+      ResultStatus = 200,
+      OccurredAt = new DateTimeOffset(2026, 2, 20, 10, 0, 0, TimeSpan.Zero)
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    var reportRepository = new Mock<IReportRepository>();
+    var accessGrantRepository = new Mock<IAccessGrantRepository>();
+    var emergencyContactRepository = new Mock<IEmergencyContactRepository>();
+    var consentRecordRepository = new Mock<IConsentRecordRepository>();
+    var auditLogRepository = new Mock<IAuditLogRepository>();
+    var unitOfWork = new Mock<IUnitOfWork>();
+    var auditLoggingService = new Mock<IAuditLoggingService>();
+    var clock = new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 12, 0, 0, TimeSpan.Zero));
+
+    userRepository.Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>())).ReturnsAsync(user);
+    reportRepository.Setup(x => x.ListAsync(It.IsAny<ISpecification<Report>>(), It.IsAny<CancellationToken>())).ReturnsAsync([report]);
+    accessGrantRepository.Setup(x => x.ListAsync(It.IsAny<ISpecification<AccessGrant>>(), It.IsAny<CancellationToken>())).ReturnsAsync([accessGrant]);
+    emergencyContactRepository.Setup(x => x.ListByUserAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync([emergencyContact]);
+    consentRecordRepository.Setup(x => x.ListAsync(It.IsAny<ISpecification<ConsentRecord>>(), It.IsAny<CancellationToken>())).ReturnsAsync([consent]);
+    auditLogRepository.Setup(x => x.ListByActorAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync([auditLog]);
+
+    var service = new UserDataRightsService(
+      userRepository.Object,
+      reportRepository.Object,
+      accessGrantRepository.Object,
+      emergencyContactRepository.Object,
+      consentRecordRepository.Object,
+      auditLogRepository.Object,
+      unitOfWork.Object,
+      auditLoggingService.Object,
+      clock);
+
+    var response = await service.ExportCurrentUserDataAsync("seed-PATIENT-1", CancellationToken.None);
+
+    response.Profile.UserId.Should().Be(user.Id);
+    response.Reports.Should().HaveCount(1);
+    response.AccessGrants.Should().HaveCount(1);
+    response.EmergencyContacts.Should().HaveCount(1);
+    response.Consents.Should().HaveCount(1);
+    response.AuditLogs.Should().HaveCount(1);
+
+    auditLoggingService.Verify(x => x.LogDataAccessAsync(
+      user,
+      "user_data.export_requested",
+      "user",
+      user.Id,
+      200,
+      It.IsAny<IReadOnlyDictionary<string, string>>(),
+      It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task DeleteCurrentUserDataAsync_ShouldThrow_WhenConfirmationFlagIsFalseAsync()
+  {
+    var service = CreateService();
+
+    var action = async () => await service.DeleteCurrentUserDataAsync(
+      "seed-PATIENT-1",
+      new DataDeletionRequest(false, "test"),
+      CancellationToken.None);
+
+    await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*ConfirmPermanentDeletion*");
+  }
+
+  [Fact]
+  public async Task DeleteCurrentUserDataAsync_ShouldAnonymizeAndDeleteRelatedDataAsync()
+  {
+    var now = new DateTimeOffset(2026, 2, 20, 12, 0, 0, TimeSpan.Zero);
+    var user = CreateUser("seed-PATIENT-1");
+    var report = new Report
+    {
+      Id = Guid.NewGuid(),
+      PatientId = user.Id,
+      UploadedByUserId = user.Id,
+      DoctorId = user.Id,
+      ReportNumber = "RPT-DEL-001",
+      ReportType = ReportType.BloodTest,
+      Status = ReportStatus.Published,
+      UploadedAt = now.AddDays(-1),
+      FileStorageKey = "reports/sample.pdf",
+      ChecksumSha256 = "abc",
+      Results = new ReportResults
+      {
+        Notes = "contains pii",
+        Parameters = [new ReportResultParameter { Code = "HB", Name = "Hemoglobin", Value = 12.3m }]
+      },
+      Metadata = new ReportMetadata
+      {
+        Tags = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["email"] = "patient@aarogya.dev"
+        }
+      },
+      Parameters = [new ReportParameter { ParameterCode = "HB", ParameterName = "Hemoglobin", MeasuredValueNumeric = 12.3m }]
+    };
+
+    var grant = new AccessGrant
+    {
+      Id = Guid.NewGuid(),
+      PatientId = user.Id,
+      GrantedToUserId = Guid.NewGuid(),
+      GrantedByUserId = user.Id,
+      StartsAt = now.AddDays(-2),
+      Status = AccessGrantStatus.Active
+    };
+
+    var contact = new EmergencyContact
+    {
+      Id = Guid.NewGuid(),
+      UserId = user.Id,
+      Name = "Parent",
+      Relationship = "Mother",
+      Phone = "+919900001111"
+    };
+
+    var consent = new ConsentRecord
+    {
+      Id = Guid.NewGuid(),
+      UserId = user.Id,
+      Purpose = "reports.share",
+      IsGranted = true,
+      Source = "api",
+      OccurredAt = now.AddDays(-1)
+    };
+
+    var auditLog = new AuditLog
+    {
+      Id = Guid.NewGuid(),
+      ActorUserId = user.Id,
+      UserAgent = "agent",
+      Action = "reports.created",
+      EntityType = "report",
+      ClientIp = System.Net.IPAddress.Parse("10.0.0.1"),
+      Details = new AuditLogDetails
+      {
+        Summary = "before",
+        Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["email"] = "patient@aarogya.dev",
+          ["event"] = "create"
+        }
+      }
+    };
+
+    var userRepository = new Mock<IUserRepository>();
+    var reportRepository = new Mock<IReportRepository>();
+    var accessGrantRepository = new Mock<IAccessGrantRepository>();
+    var emergencyContactRepository = new Mock<IEmergencyContactRepository>();
+    var consentRecordRepository = new Mock<IConsentRecordRepository>();
+    var auditLogRepository = new Mock<IAuditLogRepository>();
+    var unitOfWork = new Mock<IUnitOfWork>();
+    var auditLoggingService = new Mock<IAuditLoggingService>();
+
+    userRepository.Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>())).ReturnsAsync(user);
+    reportRepository.Setup(x => x.ListAsync(It.IsAny<ISpecification<Report>>(), It.IsAny<CancellationToken>())).ReturnsAsync([report]);
+    accessGrantRepository.Setup(x => x.ListAsync(It.IsAny<ISpecification<AccessGrant>>(), It.IsAny<CancellationToken>())).ReturnsAsync([grant]);
+    emergencyContactRepository.Setup(x => x.ListByUserAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync([contact]);
+    consentRecordRepository.Setup(x => x.ListAsync(It.IsAny<ISpecification<ConsentRecord>>(), It.IsAny<CancellationToken>())).ReturnsAsync([consent]);
+    auditLogRepository.Setup(x => x.ListByActorAsync(user.Id, It.IsAny<CancellationToken>())).ReturnsAsync([auditLog]);
+
+    var service = new UserDataRightsService(
+      userRepository.Object,
+      reportRepository.Object,
+      accessGrantRepository.Object,
+      emergencyContactRepository.Object,
+      consentRecordRepository.Object,
+      auditLogRepository.Object,
+      unitOfWork.Object,
+      auditLoggingService.Object,
+      new FixedUtcClock(now));
+
+    var response = await service.DeleteCurrentUserDataAsync(
+      "seed-PATIENT-1",
+      new DataDeletionRequest(true, "requested by user"),
+      CancellationToken.None);
+
+    user.ExternalAuthId.Should().BeNull();
+    user.Email.Should().StartWith("deleted-");
+    user.IsActive.Should().BeFalse();
+
+    report.IsDeleted.Should().BeTrue();
+    report.FileStorageKey.Should().BeNull();
+    report.ChecksumSha256.Should().BeNull();
+    report.Results.Parameters.Should().BeEmpty();
+    report.Metadata.Tags.Should().BeEmpty();
+    report.Parameters.Should().BeEmpty();
+
+    auditLog.ActorUserId.Should().BeNull();
+    auditLog.UserAgent.Should().BeNull();
+    auditLog.ClientIp.Should().BeNull();
+    auditLog.Details.Data["email"].Should().Be("[REDACTED]");
+
+    response.AffectedRecords["users"].Should().Be(1);
+    response.AffectedRecords["reports"].Should().Be(1);
+    response.AffectedRecords["auditLogsAnonymized"].Should().Be(1);
+    response.RetentionExceptions.Should().NotBeEmpty();
+
+    reportRepository.Verify(x => x.Update(report), Times.Once);
+    accessGrantRepository.Verify(x => x.Delete(grant), Times.Once);
+    emergencyContactRepository.Verify(x => x.Delete(contact), Times.Once);
+    consentRecordRepository.Verify(x => x.Delete(consent), Times.Once);
+    auditLogRepository.Verify(x => x.Update(auditLog), Times.Once);
+    userRepository.Verify(x => x.Update(user), Times.Once);
+    unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    auditLoggingService.Verify(x => x.LogDataAccessAsync(
+      user,
+      "user_data.deletion_requested",
+      "user",
+      user.Id,
+      200,
+      It.IsAny<IReadOnlyDictionary<string, string>>(),
+      It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  private static UserDataRightsService CreateService()
+  {
+    return new UserDataRightsService(
+      Mock.Of<IUserRepository>(),
+      Mock.Of<IReportRepository>(),
+      Mock.Of<IAccessGrantRepository>(),
+      Mock.Of<IEmergencyContactRepository>(),
+      Mock.Of<IConsentRecordRepository>(),
+      Mock.Of<IAuditLogRepository>(),
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAuditLoggingService>(),
+      new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 12, 0, 0, TimeSpan.Zero)));
+  }
+
+  private static User CreateUser(string sub)
+  {
+    return new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = sub,
+      Role = UserRole.Patient,
+      FirstName = "Test",
+      LastName = "Patient",
+      Email = "patient@aarogya.dev",
+      Phone = "+919999999999",
+      IsActive = true
+    };
+  }
+
+  private sealed class FixedUtcClock(DateTimeOffset utcNow) : IUtcClock
+  {
+    public DateTimeOffset UtcNow { get; } = utcNow;
+  }
+}

--- a/tests/Aarogya.Api.Tests/UsersControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/UsersControllerTests.cs
@@ -16,8 +16,7 @@ public sealed class UsersControllerTests
   [Fact]
   public async Task GetCurrentUserProfileAsync_ShouldReturnUnauthorized_WhenSubjectMissingAsync()
   {
-    var service = new Mock<IUserProfileService>();
-    var controller = CreateController(service.Object, new ClaimsPrincipal(new ClaimsIdentity()));
+    var controller = CreateController(new Mock<IUserProfileService>().Object, new ClaimsPrincipal(new ClaimsIdentity()));
 
     var result = await controller.GetCurrentUserProfileAsync(CancellationToken.None);
 
@@ -38,10 +37,10 @@ public sealed class UsersControllerTests
       new DateOnly(1995, 6, 5),
       ["Patient"]);
 
-    var service = new Mock<IUserProfileService>();
-    service.Setup(x => x.GetCurrentUserAsync("seed-PATIENT-1", It.IsAny<CancellationToken>())).ReturnsAsync(response);
+    var userProfileService = new Mock<IUserProfileService>();
+    userProfileService.Setup(x => x.GetCurrentUserAsync("seed-PATIENT-1", It.IsAny<CancellationToken>())).ReturnsAsync(response);
 
-    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-1"));
+    var controller = CreateController(userProfileService.Object, CreateUser("seed-PATIENT-1"));
 
     var result = await controller.GetCurrentUserProfileAsync(CancellationToken.None);
 
@@ -52,8 +51,7 @@ public sealed class UsersControllerTests
   [Fact]
   public async Task UpdateCurrentUserProfileAsync_ShouldReturnUnauthorized_WhenSubjectMissingAsync()
   {
-    var service = new Mock<IUserProfileService>();
-    var controller = CreateController(service.Object, new ClaimsPrincipal(new ClaimsIdentity()));
+    var controller = CreateController(new Mock<IUserProfileService>().Object, new ClaimsPrincipal(new ClaimsIdentity()));
 
     var result = await controller.UpdateCurrentUserProfileAsync(
       new UpdateUserProfileRequest("A", null, null, null, null, null, null),
@@ -65,12 +63,12 @@ public sealed class UsersControllerTests
   [Fact]
   public async Task UpdateCurrentUserProfileAsync_ShouldReturnNotFound_WhenUserMissingAsync()
   {
-    var service = new Mock<IUserProfileService>();
-    service
+    var userProfileService = new Mock<IUserProfileService>();
+    userProfileService
       .Setup(x => x.UpdateCurrentUserAsync("seed-PATIENT-1", It.IsAny<UpdateUserProfileRequest>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new KeyNotFoundException("Authenticated user is not provisioned in the database."));
 
-    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-1"));
+    var controller = CreateController(userProfileService.Object, CreateUser("seed-PATIENT-1"));
 
     var result = await controller.UpdateCurrentUserProfileAsync(
       new UpdateUserProfileRequest("A", null, null, null, null, null, null),
@@ -89,12 +87,12 @@ public sealed class UsersControllerTests
       "LOCAL",
       new AadhaarDemographicsResponse("Verified Holder", null, null, "India"));
 
-    var service = new Mock<IUserProfileService>();
-    service
+    var userProfileService = new Mock<IUserProfileService>();
+    userProfileService
       .Setup(x => x.VerifyCurrentUserAadhaarAsync("seed-PATIENT-1", It.IsAny<VerifyAadhaarRequest>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync(verification);
 
-    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-1"));
+    var controller = CreateController(userProfileService.Object, CreateUser("seed-PATIENT-1"));
 
     var result = await controller.VerifyCurrentUserAadhaarAsync(new VerifyAadhaarRequest("123456789012"), CancellationToken.None);
 
@@ -105,12 +103,12 @@ public sealed class UsersControllerTests
   [Fact]
   public async Task VerifyCurrentUserAadhaarAsync_ShouldReturnBadRequest_WhenVerificationFailsAsync()
   {
-    var service = new Mock<IUserProfileService>();
-    service
+    var userProfileService = new Mock<IUserProfileService>();
+    userProfileService
       .Setup(x => x.VerifyCurrentUserAadhaarAsync("seed-PATIENT-1", It.IsAny<VerifyAadhaarRequest>(), It.IsAny<CancellationToken>()))
       .ThrowsAsync(new InvalidOperationException("Aadhaar validation failed."));
 
-    var controller = CreateController(service.Object, CreateUser("seed-PATIENT-1"));
+    var controller = CreateController(userProfileService.Object, CreateUser("seed-PATIENT-1"));
 
     var result = await controller.VerifyCurrentUserAadhaarAsync(new VerifyAadhaarRequest("123456789012"), CancellationToken.None);
 
@@ -118,7 +116,57 @@ public sealed class UsersControllerTests
     badRequest.Value.Should().BeOfType<ValidationErrorResponse>();
   }
 
-  private static UsersController CreateController(IUserProfileService service, ClaimsPrincipal user)
+  [Fact]
+  public async Task ExportCurrentUserDataAsync_ShouldReturnOkAsync()
+  {
+    var dataRightsService = new Mock<IUserDataRightsService>();
+    dataRightsService
+      .Setup(x => x.ExportCurrentUserDataAsync("seed-PATIENT-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new DataExportResponse(
+        DateTimeOffset.UtcNow,
+        new UserProfileExportData(Guid.NewGuid(), "seed-PATIENT-1", "patient@aarogya.dev", "Test", "Patient", null, null, null, null, true, "Patient"),
+        [],
+        [],
+        [],
+        [],
+        []));
+
+    var controller = CreateController(
+      new Mock<IUserProfileService>().Object,
+      CreateUser("seed-PATIENT-1"),
+      dataRightsService.Object);
+
+    var result = await controller.ExportCurrentUserDataAsync(CancellationToken.None);
+
+    var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+    ok.Value.Should().BeOfType<DataExportResponse>();
+  }
+
+  [Fact]
+  public async Task DeleteCurrentUserDataAsync_ShouldReturnBadRequest_WhenNotConfirmedAsync()
+  {
+    var dataRightsService = new Mock<IUserDataRightsService>();
+    dataRightsService
+      .Setup(x => x.DeleteCurrentUserDataAsync("seed-PATIENT-1", It.IsAny<DataDeletionRequest>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new InvalidOperationException("ConfirmPermanentDeletion must be true to proceed."));
+
+    var controller = CreateController(
+      new Mock<IUserProfileService>().Object,
+      CreateUser("seed-PATIENT-1"),
+      dataRightsService.Object);
+
+    var result = await controller.DeleteCurrentUserDataAsync(
+      new DataDeletionRequest(false, "test"),
+      CancellationToken.None);
+
+    var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+    badRequest.Value.Should().BeOfType<ValidationErrorResponse>();
+  }
+
+  private static UsersController CreateController(
+    IUserProfileService userProfileService,
+    ClaimsPrincipal user,
+    IUserDataRightsService? userDataRightsService = null)
   {
     var consentService = new Mock<IConsentService>();
     consentService
@@ -128,7 +176,10 @@ public sealed class UsersControllerTests
         It.IsAny<CancellationToken>()))
       .Returns(Task.CompletedTask);
 
-    return new UsersController(service, consentService.Object)
+    return new UsersController(
+      userProfileService,
+      userDataRightsService ?? Mock.Of<IUserDataRightsService>(),
+      consentService.Object)
     {
       ControllerContext = new ControllerContext
       {


### PR DESCRIPTION
## Summary
- add user data rights service for portable profile data export
- add deletion flow that anonymizes user PII and removes related grants/contacts/consents
- add DPDP-focused endpoints under users: `/api/v1/users/me/export` and `/api/v1/users/me/deletion`
- add request validation, DI wiring, domain specifications, and service/controller tests

## Validation
- `dotnet format --verify-no-changes --exclude src/Aarogya.Infrastructure/Persistence/Migrations`
- `dotnet test Aarogya.sln`

Closes #71
