### PR TITLE
feat(reports): add PDF text extraction providers (PdfPig + Textract)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="AWSSDK.S3" Version="4.0.18.6" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.14" />
     <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.11.5" />
+    <PackageVersion Include="AWSSDK.Textract" Version="4.0.3.13" />
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentValidation" Version="11.9.0" />
@@ -32,6 +33,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+    <PackageVersion Include="PdfPig" Version="0.1.13" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />

--- a/src/Aarogya.Api/Aarogya.Api.csproj
+++ b/src/Aarogya.Api/Aarogya.Api.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="FluentValidation.AspNetCore" />
+    <PackageReference Include="PdfPig" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aarogya.Api/Features/V1/Reports/ITextExtractionProvider.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ITextExtractionProvider.cs
@@ -1,0 +1,16 @@
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal interface ITextExtractionProvider
+{
+  public Task<TextExtractionResult> ExtractTextAsync(
+    Stream pdfStream,
+    string objectKey,
+    CancellationToken cancellationToken = default);
+}
+
+internal sealed record TextExtractionResult(
+  string ExtractedText,
+  string Method,
+  int PageCount,
+  bool UsedOcr,
+  Dictionary<string, string> ProviderMetadata);

--- a/src/Aarogya.Api/Features/V1/Reports/PdfPigTextExtractionProvider.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/PdfPigTextExtractionProvider.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using UglyToad.PdfPig;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class PdfPigTextExtractionProvider(ILogger<PdfPigTextExtractionProvider> logger) : ITextExtractionProvider
+{
+  public Task<TextExtractionResult> ExtractTextAsync(
+    Stream pdfStream,
+    string objectKey,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(pdfStream);
+
+    logger.LogInformation(
+      "Starting PdfPig text extraction for object {ObjectKey}",
+      objectKey);
+
+    var bytes = ReadStreamToBytes(pdfStream);
+    using var document = PdfDocument.Open(bytes);
+
+    var pageCount = document.NumberOfPages;
+    var textBuilder = new StringBuilder();
+    var metadata = new Dictionary<string, string>();
+
+    if (document.Information.Producer is { } producer)
+    {
+      metadata["producer"] = producer;
+    }
+
+    if (document.Information.Creator is { } creator)
+    {
+      metadata["creator"] = creator;
+    }
+
+    metadata["page_count"] = pageCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    for (var i = 1; i <= pageCount; i++)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      var page = document.GetPage(i);
+      var pageText = page.Text;
+
+      if (!string.IsNullOrWhiteSpace(pageText))
+      {
+        textBuilder.AppendLine(pageText);
+      }
+    }
+
+    var extractedText = textBuilder.ToString().Trim();
+
+    logger.LogInformation(
+      "PdfPig extracted {CharCount} characters from {PageCount} pages for object {ObjectKey}",
+      extractedText.Length,
+      pageCount,
+      objectKey);
+
+    var result = new TextExtractionResult(
+      extractedText,
+      "pdfpig",
+      pageCount,
+      UsedOcr: false,
+      metadata);
+
+    return Task.FromResult(result);
+  }
+
+  private static byte[] ReadStreamToBytes(Stream stream)
+  {
+    if (stream is MemoryStream memoryStream)
+    {
+      return memoryStream.ToArray();
+    }
+
+    using var ms = new MemoryStream();
+    stream.CopyTo(ms);
+    return ms.ToArray();
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Reports/TextractTextExtractionProvider.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/TextractTextExtractionProvider.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using Amazon.Textract;
+using Amazon.Textract.Model;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class TextractTextExtractionProvider(
+  IAmazonTextract textractClient,
+  ILogger<TextractTextExtractionProvider> logger) : ITextExtractionProvider
+{
+  private static readonly TimeSpan PollingInterval = TimeSpan.FromSeconds(3);
+  private static readonly TimeSpan MaxPollingDuration = TimeSpan.FromMinutes(5);
+
+  public async Task<TextExtractionResult> ExtractTextAsync(
+    Stream pdfStream,
+    string objectKey,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(pdfStream);
+
+    logger.LogInformation(
+      "Starting Textract text extraction for object {ObjectKey}",
+      objectKey);
+
+    using var memoryStream = new MemoryStream();
+    await pdfStream.CopyToAsync(memoryStream, cancellationToken);
+    memoryStream.Position = 0;
+
+    var documentBytes = memoryStream.ToArray();
+
+    // Use the synchronous Textract API for small documents, async API for larger ones.
+    if (documentBytes.Length < 5 * 1024 * 1024)
+    {
+      return await ExtractWithSyncApiAsync(documentBytes, objectKey, cancellationToken);
+    }
+
+    return await ExtractWithAsyncApiAsync(objectKey, cancellationToken);
+  }
+
+  private async Task<TextExtractionResult> ExtractWithSyncApiAsync(
+    byte[] documentBytes,
+    string objectKey,
+    CancellationToken cancellationToken)
+  {
+    var request = new DetectDocumentTextRequest
+    {
+      Document = new Document
+      {
+        Bytes = new MemoryStream(documentBytes)
+      }
+    };
+
+    var response = await textractClient.DetectDocumentTextAsync(request, cancellationToken);
+
+    var (text, pageCount) = AssembleTextFromBlocks(response.Blocks);
+
+    var metadata = new Dictionary<string, string>
+    {
+      ["textract_api"] = "sync",
+      ["block_count"] = response.Blocks.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)
+    };
+
+    logger.LogInformation(
+      "Textract sync extracted {CharCount} characters from {PageCount} pages for object {ObjectKey}",
+      text.Length,
+      pageCount,
+      objectKey);
+
+    return new TextExtractionResult(text, "textract", pageCount, UsedOcr: true, metadata);
+  }
+
+  private async Task<TextExtractionResult> ExtractWithAsyncApiAsync(
+    string objectKey,
+    CancellationToken cancellationToken)
+  {
+    var startRequest = new StartDocumentTextDetectionRequest
+    {
+      DocumentLocation = new DocumentLocation
+      {
+        S3Object = new S3Object
+        {
+          Bucket = ExtractBucketFromKey(objectKey),
+          Name = ExtractNameFromKey(objectKey)
+        }
+      }
+    };
+
+    var startResponse = await textractClient.StartDocumentTextDetectionAsync(startRequest, cancellationToken);
+    var jobId = startResponse.JobId;
+
+    logger.LogInformation(
+      "Started Textract async job {JobId} for object {ObjectKey}",
+      jobId,
+      objectKey);
+
+    var allBlocks = new List<Block>();
+    var startTime = DateTimeOffset.UtcNow;
+
+    while (true)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      if (DateTimeOffset.UtcNow - startTime > MaxPollingDuration)
+      {
+        throw new TimeoutException($"Textract job {jobId} did not complete within {MaxPollingDuration.TotalMinutes} minutes.");
+      }
+
+      await Task.Delay(PollingInterval, cancellationToken);
+
+      var getRequest = new GetDocumentTextDetectionRequest { JobId = jobId };
+      var getResponse = await textractClient.GetDocumentTextDetectionAsync(getRequest, cancellationToken);
+
+      if (getResponse.JobStatus == JobStatus.FAILED)
+      {
+        throw new InvalidOperationException($"Textract job {jobId} failed: {getResponse.StatusMessage}");
+      }
+
+      if (getResponse.JobStatus == JobStatus.SUCCEEDED)
+      {
+        allBlocks.AddRange(getResponse.Blocks);
+
+        // Handle pagination
+        var nextToken = getResponse.NextToken;
+        while (!string.IsNullOrEmpty(nextToken))
+        {
+          cancellationToken.ThrowIfCancellationRequested();
+
+          var pageRequest = new GetDocumentTextDetectionRequest
+          {
+            JobId = jobId,
+            NextToken = nextToken
+          };
+
+          var pageResponse = await textractClient.GetDocumentTextDetectionAsync(pageRequest, cancellationToken);
+          allBlocks.AddRange(pageResponse.Blocks);
+          nextToken = pageResponse.NextToken;
+        }
+
+        break;
+      }
+    }
+
+    var (text, pageCount) = AssembleTextFromBlocks(allBlocks);
+
+    var metadata = new Dictionary<string, string>
+    {
+      ["textract_api"] = "async",
+      ["job_id"] = jobId,
+      ["block_count"] = allBlocks.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)
+    };
+
+    logger.LogInformation(
+      "Textract async extracted {CharCount} characters from {PageCount} pages for object {ObjectKey}",
+      text.Length,
+      pageCount,
+      objectKey);
+
+    return new TextExtractionResult(text, "textract", pageCount, UsedOcr: true, metadata);
+  }
+
+  private static (string Text, int PageCount) AssembleTextFromBlocks(List<Block> blocks)
+  {
+    var textBuilder = new StringBuilder();
+    var pageCount = 0;
+
+    foreach (var block in blocks.OrderBy(b => b.Page).ThenBy(b => b.Geometry?.BoundingBox?.Top ?? 0))
+    {
+      if (block.BlockType == BlockType.PAGE)
+      {
+        pageCount++;
+      }
+      else if (block.BlockType == BlockType.LINE && !string.IsNullOrWhiteSpace(block.Text))
+      {
+        textBuilder.AppendLine(block.Text);
+      }
+    }
+
+    return (textBuilder.ToString().Trim(), pageCount);
+  }
+
+  private static string ExtractBucketFromKey(string objectKey)
+  {
+    // objectKey format: "bucket/path/to/file.pdf" or just "path/to/file.pdf"
+    var parts = objectKey.Split('/', 2);
+    return parts.Length > 1 ? parts[0] : string.Empty;
+  }
+
+  private static string ExtractNameFromKey(string objectKey)
+  {
+    var parts = objectKey.Split('/', 2);
+    return parts.Length > 1 ? parts[1] : objectKey;
+  }
+}

--- a/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
+++ b/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.KeyManagementService" />
     <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="AWSSDK.SQS" />
+    <PackageReference Include="AWSSDK.Textract" />
     <PackageReference Include="AWSSDK.SimpleEmailV2" />
     <PackageReference Include="Bogus" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />

--- a/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
+++ b/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
@@ -8,6 +8,7 @@ using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.SimpleEmailV2;
 using Amazon.SQS;
+using Amazon.Textract;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -141,6 +142,24 @@ public static class AwsServiceRegistration
     else
     {
       services.AddAWSService<IAmazonKeyManagementService>();
+    }
+
+    // Register Textract client
+    if (useLocalStack && hasServiceUrl)
+    {
+      var useHttp = serviceUrl!.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
+      services.AddSingleton<IAmazonTextract>(_ => new AmazonTextractClient(
+        awsOptions.Credentials ?? new BasicAWSCredentials("test", "test"),
+        new AmazonTextractConfig
+        {
+          RegionEndpoint = awsOptions.Region,
+          ServiceURL = serviceUrl,
+          UseHttp = useHttp
+        }));
+    }
+    else
+    {
+      services.AddAWSService<IAmazonTextract>();
     }
 
     // Register Cognito Identity Provider client

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/PdfPigTextExtractionProviderTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/PdfPigTextExtractionProviderTests.cs
@@ -1,0 +1,115 @@
+using Aarogya.Api.Features.V1.Reports;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using UglyToad.PdfPig.Writer;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Features.V1.Reports;
+
+public sealed class PdfPigTextExtractionProviderTests
+{
+  private readonly PdfPigTextExtractionProvider _provider;
+
+  public PdfPigTextExtractionProviderTests()
+  {
+    var logger = new Mock<ILogger<PdfPigTextExtractionProvider>>();
+    _provider = new PdfPigTextExtractionProvider(logger.Object);
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldExtractTextFromDigitalPdfAsync()
+  {
+    using var pdfStream = CreatePdfWithText("Hemoglobin: 14.5 g/dL\nWBC: 7500 /uL");
+
+    var result = await _provider.ExtractTextAsync(pdfStream, "reports/test.pdf");
+
+    result.ExtractedText.Should().Contain("Hemoglobin");
+    result.ExtractedText.Should().Contain("14.5");
+    result.Method.Should().Be("pdfpig");
+    result.PageCount.Should().Be(1);
+    result.UsedOcr.Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldReturnEmptyTextForPdfWithNoTextAsync()
+  {
+    using var pdfStream = CreateEmptyPdf();
+
+    var result = await _provider.ExtractTextAsync(pdfStream, "reports/empty.pdf");
+
+    result.ExtractedText.Should().BeEmpty();
+    result.Method.Should().Be("pdfpig");
+    result.PageCount.Should().Be(1);
+    result.UsedOcr.Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldReturnMetadataWithPageCountAsync()
+  {
+    using var pdfStream = CreatePdfWithText("Test content");
+
+    var result = await _provider.ExtractTextAsync(pdfStream, "reports/meta.pdf");
+
+    result.ProviderMetadata.Should().ContainKey("page_count");
+    result.ProviderMetadata["page_count"].Should().Be("1");
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldThrowOnNullStreamAsync()
+  {
+    var act = () => _provider.ExtractTextAsync(null!, "key");
+
+    await act.Should().ThrowAsync<ArgumentNullException>();
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldHandleMemoryStreamDirectlyAsync()
+  {
+    using var pdfStream = CreatePdfWithText("Direct memory stream test");
+
+    // Ensure we're working with a MemoryStream for the optimization path
+    pdfStream.Should().BeOfType<MemoryStream>();
+
+    var result = await _provider.ExtractTextAsync(pdfStream, "reports/memory.pdf");
+
+    result.ExtractedText.Should().Contain("Direct memory stream test");
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldRespectCancellationTokenAsync()
+  {
+    using var pdfStream = CreatePdfWithText("Cancel test");
+    using var cts = new CancellationTokenSource();
+    await cts.CancelAsync();
+
+    var act = () => _provider.ExtractTextAsync(pdfStream, "reports/cancel.pdf", cts.Token);
+
+    await act.Should().ThrowAsync<OperationCanceledException>();
+  }
+
+  private static MemoryStream CreatePdfWithText(string text)
+  {
+    var builder = new PdfDocumentBuilder();
+    var page = builder.AddPage(UglyToad.PdfPig.Content.PageSize.A4);
+    var font = builder.AddStandard14Font(UglyToad.PdfPig.Fonts.Standard14Fonts.Standard14Font.Helvetica);
+
+    var yPosition = 800.0;
+    foreach (var line in text.Split('\n'))
+    {
+      page.AddText(line, 12, new UglyToad.PdfPig.Core.PdfPoint(72, yPosition), font);
+      yPosition -= 20;
+    }
+
+    var bytes = builder.Build();
+    return new MemoryStream(bytes);
+  }
+
+  private static MemoryStream CreateEmptyPdf()
+  {
+    var builder = new PdfDocumentBuilder();
+    builder.AddPage(UglyToad.PdfPig.Content.PageSize.A4);
+    var bytes = builder.Build();
+    return new MemoryStream(bytes);
+  }
+}

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/TextractTextExtractionProviderTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/TextractTextExtractionProviderTests.cs
@@ -1,0 +1,194 @@
+using Aarogya.Api.Features.V1.Reports;
+using Amazon.Textract;
+using Amazon.Textract.Model;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Features.V1.Reports;
+
+public sealed class TextractTextExtractionProviderTests
+{
+  private readonly Mock<IAmazonTextract> _textractMock;
+  private readonly TextractTextExtractionProvider _provider;
+
+  public TextractTextExtractionProviderTests()
+  {
+    _textractMock = new Mock<IAmazonTextract>();
+    var logger = new Mock<ILogger<TextractTextExtractionProvider>>();
+    _provider = new TextractTextExtractionProvider(_textractMock.Object, logger.Object);
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldUseSyncApiForSmallDocumentsAsync()
+  {
+    var blocks = new List<Block>
+    {
+      new() { BlockType = BlockType.PAGE, Page = 1 },
+      new()
+      {
+        BlockType = BlockType.LINE,
+        Text = "Hemoglobin: 14.5 g/dL",
+        Page = 1,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.1f } }
+      },
+      new()
+      {
+        BlockType = BlockType.LINE,
+        Text = "WBC: 7500 /uL",
+        Page = 1,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.2f } }
+      }
+    };
+
+    _textractMock
+      .Setup(x => x.DetectDocumentTextAsync(It.IsAny<DetectDocumentTextRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new DetectDocumentTextResponse { Blocks = blocks });
+
+    using var stream = new MemoryStream(new byte[100]);
+
+    var result = await _provider.ExtractTextAsync(stream, "reports/test.pdf");
+
+    result.ExtractedText.Should().Contain("Hemoglobin: 14.5 g/dL");
+    result.ExtractedText.Should().Contain("WBC: 7500 /uL");
+    result.Method.Should().Be("textract");
+    result.PageCount.Should().Be(1);
+    result.UsedOcr.Should().BeTrue();
+    result.ProviderMetadata.Should().ContainKey("textract_api").WhoseValue.Should().Be("sync");
+    result.ProviderMetadata.Should().ContainKey("block_count").WhoseValue.Should().Be("3");
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldAssembleBlocksInReadingOrderAsync()
+  {
+    var blocks = new List<Block>
+    {
+      new() { BlockType = BlockType.PAGE, Page = 1 },
+      new()
+      {
+        BlockType = BlockType.LINE,
+        Text = "Second line",
+        Page = 1,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.5f } }
+      },
+      new()
+      {
+        BlockType = BlockType.LINE,
+        Text = "First line",
+        Page = 1,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.1f } }
+      }
+    };
+
+    _textractMock
+      .Setup(x => x.DetectDocumentTextAsync(It.IsAny<DetectDocumentTextRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new DetectDocumentTextResponse { Blocks = blocks });
+
+    using var stream = new MemoryStream(new byte[100]);
+
+    var result = await _provider.ExtractTextAsync(stream, "reports/order.pdf");
+
+    var lines = result.ExtractedText.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+    lines[0].Should().Be("First line");
+    lines[1].Should().Be("Second line");
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldIgnoreNonLineBlocksAsync()
+  {
+    var blocks = new List<Block>
+    {
+      new() { BlockType = BlockType.PAGE, Page = 1 },
+      new()
+      {
+        BlockType = BlockType.LINE,
+        Text = "Visible text",
+        Page = 1,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.1f } }
+      },
+      new()
+      {
+        BlockType = BlockType.WORD,
+        Text = "Word block should be ignored",
+        Page = 1,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.2f } }
+      }
+    };
+
+    _textractMock
+      .Setup(x => x.DetectDocumentTextAsync(It.IsAny<DetectDocumentTextRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new DetectDocumentTextResponse { Blocks = blocks });
+
+    using var stream = new MemoryStream(new byte[100]);
+
+    var result = await _provider.ExtractTextAsync(stream, "reports/filter.pdf");
+
+    result.ExtractedText.Should().Be("Visible text");
+    result.ExtractedText.Should().NotContain("Word block");
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldCountPagesCorrectlyAsync()
+  {
+    var blocks = new List<Block>
+    {
+      new() { BlockType = BlockType.PAGE, Page = 1 },
+      new()
+      {
+        BlockType = BlockType.LINE,
+        Text = "Page 1 content",
+        Page = 1,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.1f } }
+      },
+      new() { BlockType = BlockType.PAGE, Page = 2 },
+      new()
+      {
+        BlockType = BlockType.LINE,
+        Text = "Page 2 content",
+        Page = 2,
+        Geometry = new Geometry { BoundingBox = new BoundingBox { Top = 0.1f } }
+      }
+    };
+
+    _textractMock
+      .Setup(x => x.DetectDocumentTextAsync(It.IsAny<DetectDocumentTextRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new DetectDocumentTextResponse { Blocks = blocks });
+
+    using var stream = new MemoryStream(new byte[100]);
+
+    var result = await _provider.ExtractTextAsync(stream, "reports/multipage.pdf");
+
+    result.PageCount.Should().Be(2);
+    result.ExtractedText.Should().Contain("Page 1 content");
+    result.ExtractedText.Should().Contain("Page 2 content");
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldThrowOnNullStreamAsync()
+  {
+    var act = () => _provider.ExtractTextAsync(null!, "key");
+
+    await act.Should().ThrowAsync<ArgumentNullException>();
+  }
+
+  [Fact]
+  public async Task ExtractTextAsync_ShouldReturnEmptyTextWhenNoLineBlocksAsync()
+  {
+    var blocks = new List<Block>
+    {
+      new() { BlockType = BlockType.PAGE, Page = 1 }
+    };
+
+    _textractMock
+      .Setup(x => x.DetectDocumentTextAsync(It.IsAny<DetectDocumentTextRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new DetectDocumentTextResponse { Blocks = blocks });
+
+    using var stream = new MemoryStream(new byte[100]);
+
+    var result = await _provider.ExtractTextAsync(stream, "reports/empty.pdf");
+
+    result.ExtractedText.Should().BeEmpty();
+    result.PageCount.Should().Be(1);
+  }
+}


### PR DESCRIPTION
Closes #223

## Summary
- Add `ITextExtractionProvider` abstraction with `TextExtractionResult` record for plug-and-play text extraction
- Implement `PdfPigTextExtractionProvider` for digital PDF text extraction (zero cloud cost, handles 80%+ of Indian lab PDFs)
- Implement `TextractTextExtractionProvider` for scanned PDF OCR fallback (sync API for <5MB, async API with polling for larger documents)
- Register `IAmazonTextract` in `AwsServiceRegistration` (LocalStack-aware)
- Add `PdfPig` (0.1.13) and `AWSSDK.Textract` (4.0.3.13) NuGet packages

## PR 2 of 4 — PDF Data Extraction Feature
1. Domain + Infrastructure Foundation — #222 (merged)
2. **Text Extraction Providers (PdfPig + Textract)** (this PR) — #223
3. LLM Structuring + Extraction Orchestrator — #224
4. Background Worker + API Endpoints — #225

## Test plan
- [x] PdfPig: extract text from programmatically-generated digital PDF
- [x] PdfPig: handle empty PDF (no text content)
- [x] PdfPig: metadata extraction (page count)
- [x] PdfPig: null stream argument validation
- [x] PdfPig: MemoryStream optimization path
- [x] PdfPig: cancellation token respected
- [x] Textract: sync API with mock IAmazonTextract, block assembly
- [x] Textract: reading order assembly (sorted by page + top position)
- [x] Textract: non-LINE blocks filtered out
- [x] Textract: multi-page counting
- [x] Textract: null stream argument validation
- [x] Textract: empty page handling
- [x] Full test suite passes (69 domain + 41 infrastructure + 410 API = 520 tests)
- [x] `dotnet format --verify-no-changes` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)