### PR TITLE
feat(reports): add LLM structuring and PDF extraction orchestrator

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.14" />
     <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.11.5" />
     <PackageVersion Include="AWSSDK.Textract" Version="4.0.3.13" />
+    <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.16" />
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="FluentValidation" Version="11.9.0" />
@@ -22,6 +23,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
@@ -34,6 +36,7 @@
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
     <PackageVersion Include="PdfPig" Version="0.1.13" />
+    <PackageVersion Include="OllamaSharp" Version="5.4.16" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />

--- a/src/Aarogya.Api/Aarogya.Api.csproj
+++ b/src/Aarogya.Api/Aarogya.Api.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="FluentValidation.AspNetCore" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="OllamaSharp" />
     <PackageReference Include="PdfPig" />
   </ItemGroup>
 

--- a/src/Aarogya.Api/Features/V1/Reports/BedrockChatClient.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/BedrockChatClient.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Amazon.BedrockRuntime;
+using Amazon.BedrockRuntime.Model;
+using Microsoft.Extensions.AI;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class BedrockChatClient(
+  IAmazonBedrockRuntime bedrockRuntime,
+  string modelId) : IChatClient
+{
+  [SuppressMessage("Design", "S1075:URIs should not be hardcoded", Justification = "Static metadata endpoint for AWS Bedrock.")]
+  public ChatClientMetadata Metadata { get; } = new("bedrock", new Uri("https://bedrock.amazonaws.com"), modelId);
+
+  public async Task<ChatResponse> GetResponseAsync(
+    IEnumerable<ChatMessage> messages,
+    ChatOptions? options = null,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(messages);
+
+    var messageList = messages.ToList();
+    var converseRequest = new ConverseRequest
+    {
+      ModelId = modelId,
+      Messages = MapMessages(messageList),
+      InferenceConfig = new InferenceConfiguration
+      {
+        MaxTokens = options?.MaxOutputTokens ?? 4096,
+        Temperature = options?.Temperature ?? 0.1f
+      }
+    };
+
+    var systemMessages = messageList
+      .Where(m => m.Role == ChatRole.System)
+      .SelectMany(m => m.Contents.OfType<TextContent>())
+      .Select(t => new SystemContentBlock { Text = t.Text })
+      .ToList();
+
+    if (systemMessages.Count > 0)
+    {
+      converseRequest.System = systemMessages;
+    }
+
+    var response = await bedrockRuntime.ConverseAsync(converseRequest, cancellationToken);
+
+    var responseText = response.Output?.Message?.Content
+      ?.Where(c => c.Text is not null)
+      .Select(c => c.Text)
+      .FirstOrDefault() ?? string.Empty;
+
+    var chatMessage = new ChatMessage(ChatRole.Assistant, responseText);
+
+    return new ChatResponse(chatMessage)
+    {
+      Usage = new UsageDetails
+      {
+        InputTokenCount = response.Usage?.InputTokens,
+        OutputTokenCount = response.Usage?.OutputTokens
+      }
+    };
+  }
+
+  public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+    IEnumerable<ChatMessage> messages,
+    ChatOptions? options = null,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    var response = await GetResponseAsync(messages, options, cancellationToken);
+    foreach (var message in response.Messages)
+    {
+      foreach (var content in message.Contents)
+      {
+        if (content is TextContent textContent)
+        {
+          yield return new ChatResponseUpdate
+          {
+            Role = ChatRole.Assistant,
+            Contents = [textContent]
+          };
+        }
+      }
+    }
+  }
+
+  public object? GetService(Type serviceType, object? serviceKey = null)
+  {
+    return serviceType == typeof(IChatClient) ? this : null;
+  }
+
+  public void Dispose()
+  {
+    // BedrockRuntime client lifecycle is managed by DI
+  }
+
+  private static List<Message> MapMessages(List<ChatMessage> messages)
+  {
+    return messages
+      .Where(m => m.Role != ChatRole.System)
+      .Select(m => new Message
+      {
+        Role = m.Role == ChatRole.User
+          ? ConversationRole.User
+          : ConversationRole.Assistant,
+        Content = m.Contents
+          .OfType<TextContent>()
+          .Select(t => new ContentBlock { Text = t.Text })
+          .ToList()
+      })
+      .ToList();
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Reports/ExtractionContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ExtractionContracts.cs
@@ -1,0 +1,17 @@
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed record ExtractedParameter(
+  string Code,
+  string Name,
+  decimal? NumericValue,
+  string? TextValue,
+  string? Unit,
+  string? ReferenceRange,
+  bool? IsAbnormal,
+  double Confidence);
+
+internal sealed record StructuredExtractionResult(
+  IReadOnlyList<ExtractedParameter> Parameters,
+  string? Notes,
+  double OverallConfidence,
+  string ModelId);

--- a/src/Aarogya.Api/Features/V1/Reports/IReportParameterExtractor.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/IReportParameterExtractor.cs
@@ -1,0 +1,9 @@
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal interface IReportParameterExtractor
+{
+  public Task<StructuredExtractionResult> ExtractParametersAsync(
+    string extractedText,
+    string? reportType,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Reports/IReportPdfExtractionProcessor.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/IReportPdfExtractionProcessor.cs
@@ -1,0 +1,6 @@
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal interface IReportPdfExtractionProcessor
+{
+  public Task ProcessReportAsync(Guid reportId, bool forceReprocess = false, CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Reports/LlmReportParameterExtractor.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/LlmReportParameterExtractor.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class LlmReportParameterExtractor(
+  IChatClient chatClient,
+  IOptions<PdfExtractionOptions> options,
+  ILogger<LlmReportParameterExtractor> logger) : IReportParameterExtractor
+{
+  private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+  {
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+  };
+
+  private const string SystemPrompt = """
+    You are a medical laboratory report data extraction assistant.
+    Extract all test parameters from the provided lab report text.
+
+    For each parameter, provide:
+    - code: A short standardized code (e.g., HGB, WBC, RBC, PLT, FBS, TSH)
+    - name: The full parameter name as shown in the report
+    - numericValue: The numeric measured value (null if text-only)
+    - textValue: The text value if not numeric (e.g., "Positive", "Reactive")
+    - unit: The unit of measurement (e.g., g/dL, /uL, mg/dL)
+    - referenceRange: The reference range as shown (e.g., "12.0 - 17.5")
+    - isAbnormal: true if the value is outside the reference range, false if normal, null if unknown
+    - confidence: Your confidence in this extraction (0.0 to 1.0)
+
+    Also provide:
+    - overallConfidence: Your overall confidence in the extraction (0.0 to 1.0)
+    - notes: Any relevant notes about the extraction
+
+    Respond ONLY with valid JSON matching this exact schema:
+    {
+      "parameters": [...],
+      "overallConfidence": 0.0,
+      "notes": "string or null"
+    }
+    """;
+
+  public async Task<StructuredExtractionResult> ExtractParametersAsync(
+    string extractedText,
+    string? reportType,
+    CancellationToken cancellationToken = default)
+  {
+    ArgumentException.ThrowIfNullOrWhiteSpace(extractedText);
+
+    var extractionOptions = options.Value;
+    var modelId = extractionOptions.LlmProvider == "bedrock"
+      ? extractionOptions.BedrockModelId
+      : extractionOptions.OllamaModelId;
+
+    logger.LogInformation(
+      "Starting LLM parameter extraction using {Provider}/{ModelId}",
+      extractionOptions.LlmProvider,
+      modelId);
+
+    var userPrompt = BuildUserPrompt(extractedText, reportType);
+
+    var chatMessages = new List<ChatMessage>
+    {
+      new(ChatRole.System, SystemPrompt),
+      new(ChatRole.User, userPrompt)
+    };
+
+    var chatOptions = new ChatOptions
+    {
+      MaxOutputTokens = extractionOptions.MaxTokens,
+      Temperature = 0.1f
+    };
+
+    var response = await chatClient.GetResponseAsync(chatMessages, chatOptions, cancellationToken);
+    var responseText = response.Text ?? string.Empty;
+
+    logger.LogDebug(
+      "LLM response received ({ResponseLength} chars)",
+      responseText.Length);
+
+    var result = ParseResponse(responseText, modelId, extractionOptions.MinConfidenceThreshold);
+
+    logger.LogInformation(
+      "LLM extracted {ParameterCount} parameters with {OverallConfidence:F2} overall confidence",
+      result.Parameters.Count,
+      result.OverallConfidence);
+
+    return result;
+  }
+
+  private static string BuildUserPrompt(string extractedText, string? reportType)
+  {
+    var typeHint = reportType is not null
+      ? $"This is a {reportType} report. "
+      : string.Empty;
+
+    return $"""
+      {typeHint}Extract all test parameters from the following lab report text:
+
+      ---
+      {extractedText}
+      ---
+      """;
+  }
+
+  internal static StructuredExtractionResult ParseResponse(
+    string responseText,
+    string modelId,
+    double minConfidence)
+  {
+    var jsonText = ExtractJsonFromResponse(responseText);
+
+    LlmExtractionResponse? parsed;
+    try
+    {
+      parsed = JsonSerializer.Deserialize<LlmExtractionResponse>(jsonText, JsonOptions);
+    }
+    catch (JsonException)
+    {
+      return new StructuredExtractionResult([], null, 0.0, modelId);
+    }
+
+    if (parsed?.Parameters is null)
+    {
+      return new StructuredExtractionResult([], null, 0.0, modelId);
+    }
+
+    var parameters = parsed.Parameters
+      .Where(p => !string.IsNullOrWhiteSpace(p.Name) && p.Confidence >= minConfidence)
+      .Select(p => new ExtractedParameter(
+        string.IsNullOrWhiteSpace(p.Code) ? GenerateCode(p.Name) : p.Code,
+        p.Name,
+        p.NumericValue,
+        p.TextValue,
+        p.Unit,
+        p.ReferenceRange,
+        p.IsAbnormal,
+        p.Confidence))
+      .ToList();
+
+    return new StructuredExtractionResult(
+      parameters,
+      parsed.Notes,
+      parsed.OverallConfidence,
+      modelId);
+  }
+
+  private static string ExtractJsonFromResponse(string responseText)
+  {
+    var text = responseText.Trim();
+
+    // Handle markdown code blocks
+    if (text.StartsWith("```", StringComparison.Ordinal))
+    {
+      var startIndex = text.IndexOf('{', StringComparison.Ordinal);
+      var endIndex = text.LastIndexOf('}');
+      if (startIndex >= 0 && endIndex > startIndex)
+      {
+        return text[startIndex..(endIndex + 1)];
+      }
+    }
+
+    // Try to find JSON object directly
+    var jsonStart = text.IndexOf('{', StringComparison.Ordinal);
+    var jsonEnd = text.LastIndexOf('}');
+    if (jsonStart >= 0 && jsonEnd > jsonStart)
+    {
+      return text[jsonStart..(jsonEnd + 1)];
+    }
+
+    return text;
+  }
+
+  private static string GenerateCode(string name)
+  {
+    var words = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+    if (words.Length == 1)
+    {
+      return name.Length <= 6
+        ? name.ToUpperInvariant()
+        : name[..3].ToUpperInvariant();
+    }
+
+    return string.Concat(words.Select(w => char.ToUpperInvariant(w[0])));
+  }
+
+  private sealed record LlmExtractionResponse(
+    IReadOnlyList<LlmExtractedParameter>? Parameters,
+    double OverallConfidence,
+    string? Notes);
+
+  private sealed record LlmExtractedParameter(
+    string Code,
+    string Name,
+    decimal? NumericValue,
+    string? TextValue,
+    string? Unit,
+    string? ReferenceRange,
+    bool? IsAbnormal,
+    double Confidence);
+}

--- a/src/Aarogya.Api/Features/V1/Reports/PdfExtractionOptions.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/PdfExtractionOptions.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Options classes require public visibility for configuration binding.")]
+public sealed class PdfExtractionOptions
+{
+  public const string SectionName = "PdfExtraction";
+
+  public bool EnableExtraction { get; set; } = true;
+
+  public bool EnableAutoExtractionWorker { get; set; } = true;
+
+  [Range(1, 60)]
+  public int WorkerIntervalMinutes { get; set; } = 2;
+
+  [Range(1, 50)]
+  public int BatchSize { get; set; } = 10;
+
+  [Range(10, 1000)]
+  public int MinTextLengthPerPage { get; set; } = 50;
+
+  [Range(1, 5)]
+  public int MaxRetryAttempts { get; set; } = 3;
+
+  [RegularExpression("^(ollama|bedrock)$", ErrorMessage = "LlmProvider must be 'ollama' or 'bedrock'.")]
+  public string LlmProvider { get; set; } = "ollama";
+
+  [SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "Configuration binding requires string type.")]
+  public string OllamaEndpoint { get; set; } = "http://localhost:11434";
+
+  public string OllamaModelId { get; set; } = "qwen2.5:14b-instruct";
+
+  public string BedrockModelId { get; set; } = "anthropic.claude-sonnet-4-20250514";
+
+  public string? BedrockRegion { get; set; }
+
+  [Range(100, 8000)]
+  public int MaxTokens { get; set; } = 4096;
+
+  [Range(0.0, 1.0)]
+  public double MinConfidenceThreshold { get; set; } = 0.5;
+
+  public bool StoreRawExtractedText { get; set; } = true;
+}

--- a/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
@@ -1,0 +1,243 @@
+using Aarogya.Api.Configuration;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+using Aarogya.Domain.ValueObjects;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class ReportPdfExtractionProcessor(
+  IReportRepository reportRepository,
+  IUnitOfWork unitOfWork,
+  [FromKeyedServices("pdfpig")] ITextExtractionProvider pdfPigProvider,
+  [FromKeyedServices("textract")] ITextExtractionProvider textractProvider,
+  IReportParameterExtractor llmExtractor,
+  IAmazonS3 s3Client,
+  IOptions<AwsOptions> awsOptions,
+  IOptions<PdfExtractionOptions> extractionOptions,
+  ILogger<ReportPdfExtractionProcessor> logger) : IReportPdfExtractionProcessor
+{
+  public async Task ProcessReportAsync(
+    Guid reportId,
+    bool forceReprocess = false,
+    CancellationToken cancellationToken = default)
+  {
+    var options = extractionOptions.Value;
+    if (!options.EnableExtraction)
+    {
+      logger.LogInformation("PDF extraction is disabled, skipping report {ReportId}", reportId);
+      return;
+    }
+
+    var report = await reportRepository.FirstOrDefaultAsync(
+      new ReportByIdForUpdateSpecification(reportId), cancellationToken);
+
+    if (report is null)
+    {
+      logger.LogWarning("Report {ReportId} not found for extraction", reportId);
+      return;
+    }
+
+    if (string.IsNullOrEmpty(report.FileStorageKey))
+    {
+      logger.LogWarning("Report {ReportId} has no file storage key", reportId);
+      return;
+    }
+
+    if (!forceReprocess && report.Status != ReportStatus.Clean)
+    {
+      logger.LogInformation(
+        "Report {ReportId} is in status {Status}, skipping extraction",
+        reportId,
+        report.Status);
+      return;
+    }
+
+    if (!forceReprocess && report.Extraction?.AttemptCount >= options.MaxRetryAttempts)
+    {
+      logger.LogInformation(
+        "Report {ReportId} has reached max retry attempts ({AttemptCount}), skipping",
+        reportId,
+        report.Extraction.AttemptCount);
+      return;
+    }
+
+    report.Extraction ??= new ExtractionMetadata();
+    report.Extraction.AttemptCount++;
+
+    try
+    {
+      report.Status = ReportStatus.Extracting;
+      reportRepository.Update(report);
+      await unitOfWork.SaveChangesAsync(cancellationToken);
+
+      var textResult = await ExtractTextAsync(report, options, cancellationToken);
+
+      report.Extraction.ExtractionMethod = textResult.Method;
+      report.Extraction.PageCount = textResult.PageCount;
+      report.Extraction.ExtractedAt = DateTimeOffset.UtcNow;
+
+      if (options.StoreRawExtractedText)
+      {
+        report.Extraction.RawExtractedText = textResult.ExtractedText;
+      }
+
+      foreach (var (key, value) in textResult.ProviderMetadata)
+      {
+        report.Extraction.ProviderMetadata[key] = value;
+      }
+
+      if (string.IsNullOrWhiteSpace(textResult.ExtractedText))
+      {
+        logger.LogWarning("No text extracted from report {ReportId}", reportId);
+        report.Status = ReportStatus.ExtractionFailed;
+        report.Extraction.ErrorMessage = "No text could be extracted from the PDF.";
+        reportRepository.Update(report);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return;
+      }
+
+      var reportTypeCode = report.ReportType.ToString().ToUpperInvariant();
+      var structuredResult = await llmExtractor.ExtractParametersAsync(
+        textResult.ExtractedText,
+        reportTypeCode,
+        cancellationToken);
+
+      report.Extraction.StructuringModel = structuredResult.ModelId;
+      report.Extraction.OverallConfidence = structuredResult.OverallConfidence;
+      report.Extraction.StructuredAt = DateTimeOffset.UtcNow;
+
+      if (forceReprocess)
+      {
+        RemoveExtractedParameters(report);
+      }
+
+      var addedCount = AddExtractedParameters(report, structuredResult);
+      report.Extraction.ExtractedParameterCount = addedCount;
+
+      report.Status = ReportStatus.Extracted;
+      report.Extraction.ErrorMessage = null;
+
+      reportRepository.Update(report);
+      await unitOfWork.SaveChangesAsync(cancellationToken);
+
+      logger.LogInformation(
+        "Successfully extracted {ParameterCount} parameters from report {ReportId} with confidence {Confidence:F2}",
+        addedCount,
+        reportId,
+        structuredResult.OverallConfidence);
+    }
+    catch (Exception ex) when (ex is not OperationCanceledException)
+    {
+      logger.LogError(
+        ex,
+        "Extraction failed for report {ReportId} (attempt {Attempt})",
+        reportId,
+        report.Extraction.AttemptCount);
+
+      report.Status = ReportStatus.ExtractionFailed;
+      report.Extraction.ErrorMessage = ex.Message;
+
+      reportRepository.Update(report);
+      await unitOfWork.SaveChangesAsync(cancellationToken);
+    }
+  }
+
+  private async Task<TextExtractionResult> ExtractTextAsync(
+    Report report,
+    PdfExtractionOptions options,
+    CancellationToken cancellationToken)
+  {
+    using var objectResponse = await s3Client.GetObjectAsync(new GetObjectRequest
+    {
+      BucketName = awsOptions.Value.S3.BucketName,
+      Key = report.FileStorageKey
+    }, cancellationToken);
+
+    using var memoryStream = new MemoryStream();
+    await objectResponse.ResponseStream.CopyToAsync(memoryStream, cancellationToken);
+    memoryStream.Position = 0;
+
+    var pdfPigResult = await pdfPigProvider.ExtractTextAsync(
+      memoryStream, report.FileStorageKey!, cancellationToken);
+
+    var textPerPage = pdfPigResult.PageCount > 0
+      ? pdfPigResult.ExtractedText.Length / pdfPigResult.PageCount
+      : 0;
+
+    if (textPerPage >= options.MinTextLengthPerPage)
+    {
+      return pdfPigResult;
+    }
+
+    logger.LogInformation(
+      "PdfPig yielded insufficient text ({TextPerPage} chars/page) for report with key {ObjectKey}, falling back to Textract",
+      textPerPage,
+      report.FileStorageKey);
+
+    memoryStream.Position = 0;
+    var textractResult = await textractProvider.ExtractTextAsync(
+      memoryStream, report.FileStorageKey!, cancellationToken);
+
+    // If Textract also yields little text but more than PdfPig, use Textract
+    if (textractResult.ExtractedText.Length > pdfPigResult.ExtractedText.Length)
+    {
+      return textractResult with { Method = "pdfpig+textract" };
+    }
+
+    // Otherwise return PdfPig result (even if sparse)
+    return pdfPigResult;
+  }
+
+  private static void RemoveExtractedParameters(Report report)
+  {
+    var extractedParams = report.Parameters
+      .Where(p => p.Source == "extracted")
+      .ToList();
+
+    foreach (var param in extractedParams)
+    {
+      report.Parameters.Remove(param);
+    }
+  }
+
+  private static int AddExtractedParameters(Report report, StructuredExtractionResult result)
+  {
+    var existingCodes = report.Parameters
+      .Where(p => p.Source != "extracted")
+      .Select(p => p.ParameterCode)
+      .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    var added = 0;
+    foreach (var param in result.Parameters)
+    {
+      if (existingCodes.Contains(param.Code))
+      {
+        continue;
+      }
+
+      report.Parameters.Add(new ReportParameter
+      {
+        Id = Guid.NewGuid(),
+        ReportId = report.Id,
+        ParameterCode = param.Code,
+        ParameterName = param.Name,
+        MeasuredValueNumeric = param.NumericValue,
+        MeasuredValueText = param.TextValue,
+        Unit = param.Unit,
+        ReferenceRangeText = param.ReferenceRange,
+        IsAbnormal = param.IsAbnormal,
+        Source = "extracted",
+        Confidence = param.Confidence
+      });
+
+      added++;
+    }
+
+    return added;
+  }
+}

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -6,6 +6,10 @@ using Aarogya.Api.Features.V1.EmergencyContacts;
 using Aarogya.Api.Features.V1.Notifications;
 using Aarogya.Api.Features.V1.Reports;
 using Aarogya.Api.Features.V1.Users;
+using Amazon.BedrockRuntime;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using OllamaSharp;
 
 namespace Aarogya.Api.Features.V1;
 
@@ -46,6 +50,39 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddScoped<IEmergencyAccessAuditTrailService, EmergencyAccessAuditTrailService>();
     services.AddScoped<IEmergencyContactService, EmergencyContactService>();
     services.AddScoped<IConsentService, ConsentService>();
+
+    services.AddKeyedScoped<ITextExtractionProvider, PdfPigTextExtractionProvider>("pdfpig");
+    services.AddKeyedScoped<ITextExtractionProvider, TextractTextExtractionProvider>("textract");
+    services.AddScoped<IReportParameterExtractor, LlmReportParameterExtractor>();
+    services.AddScoped<IReportPdfExtractionProcessor, ReportPdfExtractionProcessor>();
+
+    return services;
+  }
+
+  public static IServiceCollection AddLlmChatClient(
+    this IServiceCollection services,
+    IConfiguration configuration)
+  {
+    var extractionSection = configuration.GetSection(PdfExtractionOptions.SectionName);
+    var llmProvider = extractionSection["LlmProvider"] ?? "ollama";
+
+    if (llmProvider.Equals("bedrock", StringComparison.OrdinalIgnoreCase))
+    {
+      services.AddSingleton<IChatClient>(sp =>
+      {
+        var bedrockRuntime = sp.GetRequiredService<IAmazonBedrockRuntime>();
+        var options = sp.GetRequiredService<IOptions<PdfExtractionOptions>>().Value;
+        return new BedrockChatClient(bedrockRuntime, options.BedrockModelId);
+      });
+    }
+    else
+    {
+      services.AddSingleton<IChatClient>(sp =>
+      {
+        var options = sp.GetRequiredService<IOptions<PdfExtractionOptions>>().Value;
+        return new OllamaApiClient(new Uri(options.OllamaEndpoint), options.OllamaModelId);
+      });
+    }
 
     return services;
   }

--- a/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
+++ b/src/Aarogya.Infrastructure/Aarogya.Infrastructure.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.KeyManagementService" />
     <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="AWSSDK.SQS" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" />
     <PackageReference Include="AWSSDK.Textract" />
     <PackageReference Include="AWSSDK.SimpleEmailV2" />
     <PackageReference Include="Bogus" />

--- a/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
+++ b/src/Aarogya.Infrastructure/Aws/AwsServiceRegistration.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Amazon;
+using Amazon.BedrockRuntime;
 using Amazon.CloudFront;
 using Amazon.CognitoIdentityProvider;
 using Amazon.Extensions.NETCore.Setup;
@@ -142,6 +143,24 @@ public static class AwsServiceRegistration
     else
     {
       services.AddAWSService<IAmazonKeyManagementService>();
+    }
+
+    // Register Bedrock Runtime client (not available in LocalStack)
+    if (!useLocalStack)
+    {
+      var bedrockRegion = configuration.GetSection("PdfExtraction")["BedrockRegion"];
+      if (!string.IsNullOrWhiteSpace(bedrockRegion))
+      {
+#pragma warning disable CS0618 // FallbackCredentialsFactory is deprecated but remains functional
+        services.AddSingleton<IAmazonBedrockRuntime>(_ => new AmazonBedrockRuntimeClient(
+          awsOptions.Credentials ?? FallbackCredentialsFactory.GetCredentials(),
+          RegionEndpoint.GetBySystemName(bedrockRegion)));
+#pragma warning restore CS0618
+      }
+      else
+      {
+        services.AddAWSService<IAmazonBedrockRuntime>();
+      }
     }
 
     // Register Textract client

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/BedrockChatClientTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/BedrockChatClientTests.cs
@@ -1,0 +1,186 @@
+using Aarogya.Api.Features.V1.Reports;
+using Amazon.BedrockRuntime;
+using Amazon.BedrockRuntime.Model;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Features.V1.Reports;
+
+public sealed class BedrockChatClientTests : IDisposable
+{
+  private readonly Mock<IAmazonBedrockRuntime> _bedrockMock;
+  private readonly BedrockChatClient _client;
+
+  public BedrockChatClientTests()
+  {
+    _bedrockMock = new Mock<IAmazonBedrockRuntime>();
+    _client = new BedrockChatClient(_bedrockMock.Object, "anthropic.claude-sonnet-4-20250514");
+  }
+
+  [Fact]
+  public async Task GetResponseAsync_ShouldReturnResponseTextAsync()
+  {
+    SetupConverseResponse("Hello, world!");
+
+    var messages = new List<ChatMessage>
+    {
+      new(ChatRole.User, "Say hello")
+    };
+
+    var response = await _client.GetResponseAsync(messages);
+
+    response.Text.Should().Be("Hello, world!");
+  }
+
+  [Fact]
+  public async Task GetResponseAsync_ShouldMapSystemMessagesToConverseSystemAsync()
+  {
+    SetupConverseResponse("Response text");
+
+    var messages = new List<ChatMessage>
+    {
+      new(ChatRole.System, "You are a helpful assistant."),
+      new(ChatRole.User, "Hello")
+    };
+
+    await _client.GetResponseAsync(messages);
+
+    _bedrockMock.Verify(x => x.ConverseAsync(
+      It.Is<ConverseRequest>(r =>
+        r.System.Count == 1 &&
+        r.System[0].Text == "You are a helpful assistant." &&
+        r.Messages.Count == 1 &&
+        r.Messages[0].Role == ConversationRole.User),
+      It.IsAny<CancellationToken>()));
+  }
+
+  [Fact]
+  public async Task GetResponseAsync_ShouldPassChatOptionsToInferenceConfigAsync()
+  {
+    SetupConverseResponse("Response");
+
+    var messages = new List<ChatMessage> { new(ChatRole.User, "Test") };
+    var options = new ChatOptions
+    {
+      MaxOutputTokens = 1024,
+      Temperature = 0.5f
+    };
+
+    await _client.GetResponseAsync(messages, options);
+
+    _bedrockMock.Verify(x => x.ConverseAsync(
+      It.Is<ConverseRequest>(r =>
+        r.InferenceConfig.MaxTokens == 1024),
+      It.IsAny<CancellationToken>()));
+  }
+
+  [Fact]
+  public async Task GetResponseAsync_ShouldReturnUsageDetailsAsync()
+  {
+    _bedrockMock
+      .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new ConverseResponse
+      {
+        Output = new ConverseOutput
+        {
+          Message = new Message
+          {
+            Role = ConversationRole.Assistant,
+            Content = [new ContentBlock { Text = "Test" }]
+          }
+        },
+        Usage = new TokenUsage
+        {
+          InputTokens = 100,
+          OutputTokens = 50
+        }
+      });
+
+    var messages = new List<ChatMessage> { new(ChatRole.User, "Test") };
+
+    var response = await _client.GetResponseAsync(messages);
+
+    response.Usage.Should().NotBeNull();
+    response.Usage!.InputTokenCount.Should().Be(100);
+    response.Usage.OutputTokenCount.Should().Be(50);
+  }
+
+  [Fact]
+  public async Task GetResponseAsync_ShouldReturnEmptyStringWhenNoContentAsync()
+  {
+    _bedrockMock
+      .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new ConverseResponse
+      {
+        Output = new ConverseOutput
+        {
+          Message = new Message
+          {
+            Role = ConversationRole.Assistant,
+            Content = []
+          }
+        }
+      });
+
+    var messages = new List<ChatMessage> { new(ChatRole.User, "Test") };
+
+    var response = await _client.GetResponseAsync(messages);
+
+    response.Text.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task GetResponseAsync_ShouldThrowOnNullMessagesAsync()
+  {
+    var act = () => _client.GetResponseAsync(null!);
+
+    await act.Should().ThrowAsync<ArgumentNullException>();
+  }
+
+  [Fact]
+  public void Metadata_ShouldReflectModelId()
+  {
+    _client.Metadata.DefaultModelId.Should().Be("anthropic.claude-sonnet-4-20250514");
+    _client.Metadata.ProviderName.Should().Be("bedrock");
+  }
+
+  [Fact]
+  public void GetService_ShouldReturnSelfForIChatClient()
+  {
+    var service = _client.GetService(typeof(IChatClient));
+
+    service.Should().BeSameAs(_client);
+  }
+
+  [Fact]
+  public void GetService_ShouldReturnNullForOtherTypes()
+  {
+    var service = _client.GetService(typeof(string));
+
+    service.Should().BeNull();
+  }
+
+  public void Dispose()
+  {
+    _client.Dispose();
+  }
+
+  private void SetupConverseResponse(string text)
+  {
+    _bedrockMock
+      .Setup(x => x.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new ConverseResponse
+      {
+        Output = new ConverseOutput
+        {
+          Message = new Message
+          {
+            Role = ConversationRole.Assistant,
+            Content = [new ContentBlock { Text = text }]
+          }
+        }
+      });
+  }
+}

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/LlmReportParameterExtractorTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/LlmReportParameterExtractorTests.cs
@@ -1,0 +1,239 @@
+using Aarogya.Api.Features.V1.Reports;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Features.V1.Reports;
+
+public sealed class LlmReportParameterExtractorTests
+{
+  private readonly Mock<IChatClient> _chatClientMock;
+  private readonly LlmReportParameterExtractor _extractor;
+
+  public LlmReportParameterExtractorTests()
+  {
+    _chatClientMock = new Mock<IChatClient>();
+    var options = Options.Create(new PdfExtractionOptions
+    {
+      LlmProvider = "ollama",
+      OllamaModelId = "test-model",
+      MaxTokens = 4096,
+      MinConfidenceThreshold = 0.5
+    });
+    var logger = new Mock<ILogger<LlmReportParameterExtractor>>();
+    _extractor = new LlmReportParameterExtractor(
+      _chatClientMock.Object, options, logger.Object);
+  }
+
+  [Fact]
+  public async Task ExtractParametersAsync_ShouldReturnStructuredResultAsync()
+  {
+    var json = """
+      {
+        "parameters": [
+          {
+            "code": "HGB",
+            "name": "Hemoglobin",
+            "numericValue": 14.5,
+            "textValue": null,
+            "unit": "g/dL",
+            "referenceRange": "12.0 - 17.5",
+            "isAbnormal": false,
+            "confidence": 0.95
+          }
+        ],
+        "overallConfidence": 0.95,
+        "notes": null
+      }
+      """;
+
+    SetupChatResponse(json);
+
+    var result = await _extractor.ExtractParametersAsync("Hemoglobin: 14.5 g/dL", "blood_test");
+
+    result.Parameters.Should().HaveCount(1);
+    result.Parameters[0].Code.Should().Be("HGB");
+    result.Parameters[0].Name.Should().Be("Hemoglobin");
+    result.Parameters[0].NumericValue.Should().Be(14.5m);
+    result.Parameters[0].Unit.Should().Be("g/dL");
+    result.OverallConfidence.Should().Be(0.95);
+    result.ModelId.Should().Be("test-model");
+  }
+
+  [Fact]
+  public async Task ExtractParametersAsync_ShouldThrowOnNullTextAsync()
+  {
+    var act = () => _extractor.ExtractParametersAsync(null!, "blood_test");
+
+    await act.Should().ThrowAsync<ArgumentException>();
+  }
+
+  [Fact]
+  public async Task ExtractParametersAsync_ShouldThrowOnWhitespaceTextAsync()
+  {
+    var act = () => _extractor.ExtractParametersAsync("   ", "blood_test");
+
+    await act.Should().ThrowAsync<ArgumentException>();
+  }
+
+  [Fact]
+  public async Task ExtractParametersAsync_ShouldSendSystemAndUserMessagesAsync()
+  {
+    SetupChatResponse("""{"parameters": [], "overallConfidence": 0.0, "notes": null}""");
+
+    await _extractor.ExtractParametersAsync("Test text", "blood_test");
+
+    _chatClientMock.Verify(x => x.GetResponseAsync(
+      It.Is<IEnumerable<ChatMessage>>(msgs =>
+        msgs.Count() == 2 &&
+        msgs.First().Role == ChatRole.System &&
+        msgs.Last().Role == ChatRole.User),
+      It.IsAny<ChatOptions>(),
+      It.IsAny<CancellationToken>()));
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldHandleMarkdownCodeBlockAsync()
+  {
+    var responseText = """
+      ```json
+      {
+        "parameters": [
+          {"code": "WBC", "name": "White Blood Cells", "numericValue": 7500, "unit": "/uL", "referenceRange": "4000-11000", "isAbnormal": false, "confidence": 0.9}
+        ],
+        "overallConfidence": 0.9,
+        "notes": null
+      }
+      ```
+      """;
+
+    var result = LlmReportParameterExtractor.ParseResponse(responseText, "test-model", 0.5);
+
+    result.Parameters.Should().HaveCount(1);
+    result.Parameters[0].Code.Should().Be("WBC");
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldHandleJsonWithSurroundingTextAsync()
+  {
+    var responseText = """
+      Here is the extracted data:
+      {"parameters": [{"code": "PLT", "name": "Platelets", "numericValue": 250000, "unit": "/uL", "confidence": 0.85}], "overallConfidence": 0.85, "notes": null}
+      Hope this helps!
+      """;
+
+    var result = LlmReportParameterExtractor.ParseResponse(responseText, "test-model", 0.5);
+
+    result.Parameters.Should().HaveCount(1);
+    result.Parameters[0].Code.Should().Be("PLT");
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldFilterBelowConfidenceThresholdAsync()
+  {
+    var json = """
+      {
+        "parameters": [
+          {"code": "HGB", "name": "Hemoglobin", "numericValue": 14.5, "confidence": 0.9},
+          {"code": "LOW", "name": "Low Confidence", "numericValue": 1.0, "confidence": 0.2}
+        ],
+        "overallConfidence": 0.55,
+        "notes": null
+      }
+      """;
+
+    var result = LlmReportParameterExtractor.ParseResponse(json, "test-model", 0.5);
+
+    result.Parameters.Should().HaveCount(1);
+    result.Parameters[0].Code.Should().Be("HGB");
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldFilterParametersWithEmptyNameAsync()
+  {
+    var json = """
+      {
+        "parameters": [
+          {"code": "HGB", "name": "Hemoglobin", "numericValue": 14.5, "confidence": 0.9},
+          {"code": "X", "name": "", "numericValue": 0, "confidence": 0.9},
+          {"code": "Y", "name": "  ", "numericValue": 0, "confidence": 0.9}
+        ],
+        "overallConfidence": 0.7,
+        "notes": null
+      }
+      """;
+
+    var result = LlmReportParameterExtractor.ParseResponse(json, "test-model", 0.5);
+
+    result.Parameters.Should().HaveCount(1);
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldReturnEmptyWhenNullParametersAsync()
+  {
+    var json = """{"parameters": null, "overallConfidence": 0.0, "notes": null}""";
+
+    var result = LlmReportParameterExtractor.ParseResponse(json, "test-model", 0.5);
+
+    result.Parameters.Should().BeEmpty();
+    result.OverallConfidence.Should().Be(0.0);
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldGenerateCodeFromNameWhenCodeMissingAsync()
+  {
+    var json = """
+      {
+        "parameters": [
+          {"code": "", "name": "Total Cholesterol", "numericValue": 200, "confidence": 0.8}
+        ],
+        "overallConfidence": 0.8,
+        "notes": null
+      }
+      """;
+
+    var result = LlmReportParameterExtractor.ParseResponse(json, "test-model", 0.5);
+
+    result.Parameters[0].Code.Should().Be("TC");
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldGenerateCodeFromSingleWordNameAsync()
+  {
+    var json = """
+      {
+        "parameters": [
+          {"code": "", "name": "Iron", "numericValue": 80, "confidence": 0.8}
+        ],
+        "overallConfidence": 0.8,
+        "notes": null
+      }
+      """;
+
+    var result = LlmReportParameterExtractor.ParseResponse(json, "test-model", 0.5);
+
+    result.Parameters[0].Code.Should().Be("IRON");
+  }
+
+  [Fact]
+  public void ParseResponse_ShouldReturnEmptyOnInvalidJsonAsync()
+  {
+    var result = LlmReportParameterExtractor.ParseResponse("not json at all", "test-model", 0.5);
+
+    result.Parameters.Should().BeEmpty();
+  }
+
+  private void SetupChatResponse(string text)
+  {
+    var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, text));
+    _chatClientMock
+      .Setup(x => x.GetResponseAsync(
+        It.IsAny<IEnumerable<ChatMessage>>(),
+        It.IsAny<ChatOptions>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync(response);
+  }
+}

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportPdfExtractionProcessorTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportPdfExtractionProcessorTests.cs
@@ -1,0 +1,342 @@
+using Aarogya.Api.Configuration;
+using Aarogya.Api.Features.V1.Reports;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+using Aarogya.Domain.ValueObjects;
+using Amazon.S3;
+using Amazon.S3.Model;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Features.V1.Reports;
+
+public sealed class ReportPdfExtractionProcessorTests
+{
+  private readonly Mock<IReportRepository> _reportRepoMock;
+  private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+  private readonly Mock<ITextExtractionProvider> _pdfPigMock;
+  private readonly Mock<ITextExtractionProvider> _textractMock;
+  private readonly Mock<IReportParameterExtractor> _llmExtractorMock;
+  private readonly Mock<IAmazonS3> _s3Mock;
+  private readonly ReportPdfExtractionProcessor _processor;
+
+  private static readonly PdfExtractionOptions DefaultOptions = new()
+  {
+    EnableExtraction = true,
+    MinTextLengthPerPage = 50,
+    MaxRetryAttempts = 3,
+    StoreRawExtractedText = true,
+    LlmProvider = "ollama",
+    OllamaModelId = "test-model",
+    MinConfidenceThreshold = 0.5
+  };
+
+  public ReportPdfExtractionProcessorTests()
+  {
+    _reportRepoMock = new Mock<IReportRepository>();
+    _unitOfWorkMock = new Mock<IUnitOfWork>();
+    _s3Mock = new Mock<IAmazonS3>();
+    _pdfPigMock = new Mock<ITextExtractionProvider>();
+    _textractMock = new Mock<ITextExtractionProvider>();
+    _llmExtractorMock = new Mock<IReportParameterExtractor>();
+
+    var awsOptions = Options.Create(new AwsOptions { S3 = new S3Options { BucketName = "test-bucket" } });
+    var extractionOptions = Options.Create(DefaultOptions);
+    var logger = new Mock<ILogger<ReportPdfExtractionProcessor>>();
+
+    _processor = new ReportPdfExtractionProcessor(
+      _reportRepoMock.Object,
+      _unitOfWorkMock.Object,
+      _pdfPigMock.Object,
+      _textractMock.Object,
+      _llmExtractorMock.Object,
+      _s3Mock.Object,
+      awsOptions,
+      extractionOptions,
+      logger.Object);
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldSkipWhenExtractionDisabledAsync()
+  {
+    var awsOptions = Options.Create(new AwsOptions { S3 = new S3Options { BucketName = "test-bucket" } });
+    var disabledOptions = Options.Create(new PdfExtractionOptions { EnableExtraction = false });
+    var logger = new Mock<ILogger<ReportPdfExtractionProcessor>>();
+
+    var processor = new ReportPdfExtractionProcessor(
+      _reportRepoMock.Object,
+      _unitOfWorkMock.Object,
+      _pdfPigMock.Object,
+      _textractMock.Object,
+      _llmExtractorMock.Object,
+      _s3Mock.Object,
+      awsOptions,
+      disabledOptions,
+      logger.Object);
+
+    await processor.ProcessReportAsync(Guid.NewGuid());
+
+    _reportRepoMock.Verify(
+      x => x.FirstOrDefaultAsync(It.IsAny<ISpecification<Report>>(), It.IsAny<CancellationToken>()),
+      Times.Never);
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldSkipWhenReportNotFoundAsync()
+  {
+    _reportRepoMock
+      .Setup(x => x.FirstOrDefaultAsync(It.IsAny<ReportByIdForUpdateSpecification>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync((Report?)null);
+
+    await _processor.ProcessReportAsync(Guid.NewGuid());
+
+    _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldSkipWhenNoFileStorageKeyAsync()
+  {
+    var report = CreateReport(fileStorageKey: null);
+    SetupReportLookup(report);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldSkipWhenStatusNotCleanAsync()
+  {
+    var report = CreateReport(status: ReportStatus.Uploaded);
+    SetupReportLookup(report);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldSkipWhenMaxRetriesReachedAsync()
+  {
+    var report = CreateReport();
+    report.Extraction = new ExtractionMetadata { AttemptCount = 3 };
+    SetupReportLookup(report);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldExtractAndSaveParametersAsync()
+  {
+    var report = CreateReport();
+    SetupReportLookup(report);
+    SetupS3Download("Hemoglobin: 14.5 g/dL");
+    SetupPdfPigExtraction("Hemoglobin: 14.5 g/dL Reference: 12.0 - 17.5 Normal result in report", 1);
+    SetupLlmExtraction(
+    [
+      new ExtractedParameter("HGB", "Hemoglobin", 14.5m, null, "g/dL", "12.0-17.5", false, 0.95)
+    ]);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    report.Status.Should().Be(ReportStatus.Extracted);
+    report.Parameters.Should().HaveCount(1);
+    report.Parameters.First().ParameterCode.Should().Be("HGB");
+    report.Parameters.First().Source.Should().Be("extracted");
+    report.Extraction.Should().NotBeNull();
+    report.Extraction!.ExtractionMethod.Should().Be("pdfpig");
+    report.Extraction.ExtractedParameterCount.Should().Be(1);
+    _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.AtLeast(2));
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldFallbackToTextractWhenPdfPigInsufficientAsync()
+  {
+    var report = CreateReport();
+    SetupReportLookup(report);
+    SetupS3Download("x");
+    SetupPdfPigExtraction("x", 1);
+    SetupTextractExtraction("Hemoglobin: 14.5 g/dL Reference: 12.0-17.5 Normal result in report", 1);
+    SetupLlmExtraction(
+    [
+      new ExtractedParameter("HGB", "Hemoglobin", 14.5m, null, "g/dL", "12.0-17.5", false, 0.9)
+    ]);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    report.Status.Should().Be(ReportStatus.Extracted);
+    report.Extraction!.ExtractionMethod.Should().Be("pdfpig+textract");
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldSetExtractionFailedOnEmptyTextAsync()
+  {
+    var report = CreateReport();
+    SetupReportLookup(report);
+    SetupS3Download("");
+    SetupPdfPigExtraction("", 0);
+    SetupTextractExtraction("", 0);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    report.Status.Should().Be(ReportStatus.ExtractionFailed);
+    report.Extraction!.ErrorMessage.Should().Contain("No text");
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldHandleExceptionGracefullyAsync()
+  {
+    var report = CreateReport();
+    SetupReportLookup(report);
+    _s3Mock
+      .Setup(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new InvalidOperationException("S3 error"));
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    report.Status.Should().Be(ReportStatus.ExtractionFailed);
+    report.Extraction!.ErrorMessage.Should().Be("S3 error");
+    report.Extraction.AttemptCount.Should().Be(1);
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldNotOverwriteManualParametersAsync()
+  {
+    var report = CreateReport();
+    report.Parameters.Add(new ReportParameter
+    {
+      Id = Guid.NewGuid(),
+      ReportId = report.Id,
+      ParameterCode = "HGB",
+      ParameterName = "Hemoglobin",
+      MeasuredValueNumeric = 15.0m,
+      Source = "manual"
+    });
+    SetupReportLookup(report);
+    SetupS3Download("Hemoglobin: 14.5 g/dL WBC: 7500 /uL");
+    SetupPdfPigExtraction("Hemoglobin: 14.5 g/dL WBC: 7500 /uL plus more content for threshold", 1);
+    SetupLlmExtraction(
+    [
+      new ExtractedParameter("HGB", "Hemoglobin", 14.5m, null, "g/dL", "12.0-17.5", false, 0.95),
+      new ExtractedParameter("WBC", "White Blood Cells", 7500m, null, "/uL", "4000-11000", false, 0.9)
+    ]);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    report.Parameters.Should().HaveCount(2);
+    var manualParam = report.Parameters.Single(p => p.Source == "manual");
+    manualParam.MeasuredValueNumeric.Should().Be(15.0m);
+    var extractedParam = report.Parameters.Single(p => p.Source == "extracted");
+    extractedParam.ParameterCode.Should().Be("WBC");
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldRemoveExtractedParamsOnForceReprocessAsync()
+  {
+    var report = CreateReport(status: ReportStatus.Extracted);
+    report.Extraction = new ExtractionMetadata { AttemptCount = 1 };
+    report.Parameters.Add(new ReportParameter
+    {
+      Id = Guid.NewGuid(),
+      ReportId = report.Id,
+      ParameterCode = "OLD",
+      ParameterName = "Old Extracted",
+      Source = "extracted"
+    });
+    report.Parameters.Add(new ReportParameter
+    {
+      Id = Guid.NewGuid(),
+      ReportId = report.Id,
+      ParameterCode = "MANUAL",
+      ParameterName = "Manual Entry",
+      Source = "manual"
+    });
+    SetupReportLookup(report);
+    SetupS3Download("Fresh text");
+    SetupPdfPigExtraction("Fresh text for extraction with enough content per page to pass threshold", 1);
+    SetupLlmExtraction(
+    [
+      new ExtractedParameter("NEW", "New Extracted", 42m, null, "mg/dL", "10-50", false, 0.85)
+    ]);
+
+    await _processor.ProcessReportAsync(report.Id, forceReprocess: true);
+
+    report.Parameters.Should().HaveCount(2);
+    report.Parameters.Should().Contain(p => p.ParameterCode == "MANUAL");
+    report.Parameters.Should().Contain(p => p.ParameterCode == "NEW");
+    report.Parameters.Should().NotContain(p => p.ParameterCode == "OLD");
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldStoreRawTextWhenConfiguredAsync()
+  {
+    var report = CreateReport();
+    SetupReportLookup(report);
+    SetupS3Download("Raw extracted text from PDF document");
+    SetupPdfPigExtraction("Raw extracted text from PDF document with lots of content that exceeds min threshold", 1);
+    SetupLlmExtraction([]);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    report.Extraction!.RawExtractedText.Should().NotBeNull();
+  }
+
+  private static Report CreateReport(
+    ReportStatus status = ReportStatus.Clean,
+    string? fileStorageKey = "reports/test.pdf")
+  {
+    return new Report
+    {
+      Id = Guid.NewGuid(),
+      ReportNumber = "RPT-001",
+      PatientId = Guid.NewGuid(),
+      UploadedByUserId = Guid.NewGuid(),
+      ReportType = ReportType.BloodTest,
+      Status = status,
+      FileStorageKey = fileStorageKey
+    };
+  }
+
+  private void SetupReportLookup(Report report)
+  {
+    _reportRepoMock
+      .Setup(x => x.FirstOrDefaultAsync(It.IsAny<ReportByIdForUpdateSpecification>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(report);
+  }
+
+  private void SetupS3Download(string content)
+  {
+    var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(content));
+    _s3Mock
+      .Setup(x => x.GetObjectAsync(It.IsAny<GetObjectRequest>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new GetObjectResponse { ResponseStream = stream });
+  }
+
+  private void SetupPdfPigExtraction(string text, int pageCount)
+  {
+    _pdfPigMock
+      .Setup(x => x.ExtractTextAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new TextExtractionResult(text, "pdfpig", pageCount, false, new Dictionary<string, string>()));
+  }
+
+  private void SetupTextractExtraction(string text, int pageCount)
+  {
+    _textractMock
+      .Setup(x => x.ExtractTextAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new TextExtractionResult(text, "textract", pageCount, true, new Dictionary<string, string>()));
+  }
+
+  private void SetupLlmExtraction(IReadOnlyList<ExtractedParameter> parameters)
+  {
+    _llmExtractorMock
+      .Setup(x => x.ExtractParametersAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new StructuredExtractionResult(parameters, null, 0.9, "test-model"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `Microsoft.Extensions.AI`, `OllamaSharp`, and `AWSSDK.BedrockRuntime` NuGet packages for plug-and-play LLM provider support
- Create `BedrockChatClient` as an `IChatClient` adapter for AWS Bedrock Converse API (production LLM)
- Create `LlmReportParameterExtractor` with medical lab report system prompt and JSON response parsing
- Create `ReportPdfExtractionProcessor` orchestrator: S3 download → PdfPig text extraction → Textract OCR fallback → LLM structuring → persist as `ReportParameter` entities
- Add `PdfExtractionOptions` configuration class with validation
- Introduce `IReportParameterExtractor` and `IReportPdfExtractionProcessor` interfaces
- Register keyed `ITextExtractionProvider` services (pdfpig/textract) and configurable `IChatClient` (Ollama for dev, Bedrock for prod)
- Register `IAmazonBedrockRuntime` in AWS service registration with optional region override
- Add 33 unit tests covering `BedrockChatClient`, `LlmReportParameterExtractor`, and `ReportPdfExtractionProcessor`

## Test plan
- [x] All 443 API unit tests pass
- [x] All 69 domain unit tests pass
- [x] `dotnet format --verify-no-changes` passes
- [x] Build succeeds with zero errors
- [ ] CI pipeline passes (build, test, lint)

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)