### PR TITLE
feat(reports): add extraction background worker and API endpoints

### DIFF
--- a/src/Aarogya.Api/Controllers/V1/ReportsController.cs
+++ b/src/Aarogya.Api/Controllers/V1/ReportsController.cs
@@ -33,17 +33,20 @@ public sealed class ReportsController : ControllerBase
   private readonly IReportService _reportService;
   private readonly IReportFileUploadService _reportFileUploadService;
   private readonly IReportChecksumVerificationService _reportChecksumVerificationService;
+  private readonly IReportExtractionService _reportExtractionService;
   private readonly IConsentService _consentService;
 
   public ReportsController(
     IReportService reportService,
     IReportFileUploadService reportFileUploadService,
     IReportChecksumVerificationService reportChecksumVerificationService,
+    IReportExtractionService reportExtractionService,
     IConsentService consentService)
   {
     _reportService = reportService;
     _reportFileUploadService = reportFileUploadService;
     _reportChecksumVerificationService = reportChecksumVerificationService;
+    _reportExtractionService = reportExtractionService;
     _consentService = consentService;
   }
 
@@ -360,6 +363,95 @@ public sealed class ReportsController : ControllerBase
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
         {
           ["checksum"] = [ex.Message]
+        }));
+    }
+  }
+
+  [HttpGet("{id:guid}/extraction")]
+  [ProducesResponseType(typeof(ExtractionStatusResponse), StatusCodes.Status200OK)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status403Forbidden)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<IActionResult> GetExtractionStatusAsync(Guid id, CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    try
+    {
+      await _consentService.EnsureGrantedAsync(userSub, ConsentPurposeCatalog.MedicalRecordsProcessing, cancellationToken);
+      var result = await _reportExtractionService.GetExtractionStatusAsync(userSub, id, cancellationToken);
+      return result is null ? NotFound() : Ok(result);
+    }
+    catch (ConsentRequiredException ex)
+    {
+      return ForbidWithConsentError(ex.Purpose);
+    }
+    catch (KeyNotFoundException ex)
+    {
+      return NotFound(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["report"] = [ex.Message]
+        }));
+    }
+    catch (UnauthorizedAccessException)
+    {
+      return Forbid();
+    }
+  }
+
+  [HttpPost("{id:guid}/extract")]
+  [ProducesResponseType(StatusCodes.Status202Accepted)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+  [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status403Forbidden)]
+  [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+  [ProducesResponseType(StatusCodes.Status404NotFound)]
+  public async Task<IActionResult> TriggerExtractionAsync(
+    Guid id,
+    [FromBody] TriggerExtractionRequest request,
+    CancellationToken cancellationToken)
+  {
+    var userSub = User.GetSubjectOrNull();
+    if (userSub is null)
+    {
+      return Unauthorized();
+    }
+
+    try
+    {
+      await _consentService.EnsureGrantedAsync(userSub, ConsentPurposeCatalog.MedicalRecordsProcessing, cancellationToken);
+      await _reportExtractionService.TriggerExtractionAsync(userSub, id, request.ForceReprocess, cancellationToken);
+      return Accepted();
+    }
+    catch (ConsentRequiredException ex)
+    {
+      return ForbidWithConsentError(ex.Purpose);
+    }
+    catch (KeyNotFoundException ex)
+    {
+      return NotFound(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["report"] = [ex.Message]
+        }));
+    }
+    catch (UnauthorizedAccessException)
+    {
+      return Forbid();
+    }
+    catch (InvalidOperationException ex)
+    {
+      return BadRequest(new ValidationErrorResponse(
+        "Validation failed.",
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+          ["extraction"] = [ex.Message]
         }));
     }
   }

--- a/src/Aarogya.Api/Features/V1/Reports/IReportExtractionService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/IReportExtractionService.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public controller constructor injection.")]
+public interface IReportExtractionService
+{
+  public Task<ExtractionStatusResponse?> GetExtractionStatusAsync(
+    string userSub,
+    Guid reportId,
+    CancellationToken cancellationToken = default);
+
+  public Task TriggerExtractionAsync(
+    string userSub,
+    Guid reportId,
+    bool forceReprocess = false,
+    CancellationToken cancellationToken = default);
+}

--- a/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportContracts.cs
@@ -92,7 +92,30 @@ public sealed record ReportDetailResponse(
   DateTimeOffset? ReportedAt,
   string? Notes,
   IReadOnlyList<ReportDetailParameterResponse> Parameters,
-  ReportSignedDownloadUrlResponse Download);
+  ReportSignedDownloadUrlResponse Download,
+  ExtractionStatusResponse? Extraction = null);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Referenced by public API action signature.")]
+public sealed record ExtractionStatusResponse(
+  Guid ReportId,
+  string Status,
+  string? ExtractionMethod,
+  string? StructuringModel,
+  int ExtractedParameterCount,
+  double? OverallConfidence,
+  int? PageCount,
+  DateTimeOffset? ExtractedAt,
+  string? ErrorMessage,
+  int AttemptCount);
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Used by public API action signature for model binding.")]
+public sealed record TriggerExtractionRequest(bool ForceReprocess = false);
 
 [SuppressMessage(
   "Performance",

--- a/src/Aarogya.Api/Features/V1/Reports/ReportExtractionService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportExtractionService.cs
@@ -1,0 +1,119 @@
+using Aarogya.Api.Authentication;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+internal sealed class ReportExtractionService(
+  IUserRepository userRepository,
+  IReportRepository reportRepository,
+  IAccessGrantRepository accessGrantRepository,
+  IReportPdfExtractionProcessor extractionProcessor,
+  IUtcClock clock) : IReportExtractionService
+{
+  public async Task<ExtractionStatusResponse?> GetExtractionStatusAsync(
+    string userSub,
+    Guid reportId,
+    CancellationToken cancellationToken = default)
+  {
+    var report = await GetAuthorizedReportAsync(userSub, reportId, cancellationToken);
+
+    if (report.Extraction is null)
+    {
+      return null;
+    }
+
+    return MapExtractionStatus(report);
+  }
+
+  public async Task TriggerExtractionAsync(
+    string userSub,
+    Guid reportId,
+    bool forceReprocess = false,
+    CancellationToken cancellationToken = default)
+  {
+    var report = await GetAuthorizedReportAsync(userSub, reportId, cancellationToken);
+
+    if (string.IsNullOrEmpty(report.FileStorageKey))
+    {
+      throw new InvalidOperationException("Report has no uploaded file.");
+    }
+
+    if (!forceReprocess && report.Status is not (ReportStatus.Clean or ReportStatus.ExtractionFailed))
+    {
+      throw new InvalidOperationException(
+        $"Report is in status '{report.Status}' and cannot be extracted. " +
+        "Use forceReprocess=true to re-extract.");
+    }
+
+    await extractionProcessor.ProcessReportAsync(reportId, forceReprocess, cancellationToken);
+  }
+
+  private async Task<Report> GetAuthorizedReportAsync(
+    string userSub,
+    Guid reportId,
+    CancellationToken cancellationToken)
+  {
+    var user = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken)
+      ?? throw new InvalidOperationException("Authenticated user is not provisioned in the database.");
+
+    var report = await reportRepository.FirstOrDefaultAsync(
+      new ReportByIdSpecification(reportId),
+      cancellationToken)
+      ?? throw new KeyNotFoundException("Report not found.");
+
+    var canAccess = await CanAccessReportAsync(user, report, cancellationToken);
+    if (!canAccess)
+    {
+      throw new UnauthorizedAccessException("You do not have access to this report.");
+    }
+
+    return report;
+  }
+
+  private async Task<bool> CanAccessReportAsync(
+    User user,
+    Report report,
+    CancellationToken cancellationToken)
+  {
+    if (user.Role == UserRole.Patient)
+    {
+      return report.PatientId == user.Id;
+    }
+
+    if (user.Role == UserRole.LabTechnician)
+    {
+      return report.UploadedByUserId == user.Id;
+    }
+
+    if (user.Role != UserRole.Doctor)
+    {
+      return false;
+    }
+
+    var now = clock.UtcNow;
+    var grants = await accessGrantRepository.ListAsync(
+      new ActiveAccessGrantsForDoctorSpecification(user.Id, now),
+      cancellationToken);
+
+    return grants.Any(g => g.PatientId == report.PatientId);
+  }
+
+  private static ExtractionStatusResponse MapExtractionStatus(Report report)
+  {
+    var extraction = report.Extraction!;
+    return new ExtractionStatusResponse(
+      report.Id,
+      report.Status.ToString(),
+      extraction.ExtractionMethod,
+      extraction.StructuringModel,
+      extraction.ExtractedParameterCount,
+      extraction.OverallConfidence,
+      extraction.PageCount,
+      extraction.ExtractedAt,
+      extraction.ErrorMessage,
+      extraction.AttemptCount);
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionHostedService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionHostedService.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics.CodeAnalysis;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+using Microsoft.Extensions.Options;
+
+namespace Aarogya.Api.Features.V1.Reports;
+
+[SuppressMessage(
+  "Major Code Smell",
+  "S3267",
+  Justification = "Loop requires per-item async error handling which LINQ Select cannot express.")]
+internal sealed class ReportPdfExtractionHostedService(
+  IServiceScopeFactory scopeFactory,
+  IOptions<PdfExtractionOptions> extractionOptions,
+  ILogger<ReportPdfExtractionHostedService> logger)
+  : BackgroundService
+{
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    var options = extractionOptions.Value;
+    if (!options.EnableAutoExtractionWorker)
+    {
+      logger.LogInformation("PDF extraction worker is disabled.");
+      return;
+    }
+
+    var interval = TimeSpan.FromMinutes(Math.Max(1, options.WorkerIntervalMinutes));
+    while (!stoppingToken.IsCancellationRequested)
+    {
+      try
+      {
+        await RunExtractionCycleAsync(options, stoppingToken);
+      }
+      catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+      {
+        break;
+      }
+      catch (Exception ex)
+      {
+        logger.LogError(ex, "Unexpected error during PDF extraction cycle.");
+      }
+
+      await Task.Delay(interval, stoppingToken);
+    }
+  }
+
+  private async Task RunExtractionCycleAsync(
+    PdfExtractionOptions options,
+    CancellationToken cancellationToken)
+  {
+    await using var scope = scopeFactory.CreateAsyncScope();
+    var reportRepository = scope.ServiceProvider.GetRequiredService<IReportRepository>();
+    var processor = scope.ServiceProvider.GetRequiredService<IReportPdfExtractionProcessor>();
+
+    var cleanReports = await reportRepository.ListAsync(
+      new CleanReportsAwaitingExtractionSpecification(options.BatchSize),
+      cancellationToken);
+
+    if (cleanReports.Count == 0)
+    {
+      return;
+    }
+
+    logger.LogInformation(
+      "Found {Count} clean reports awaiting PDF extraction.",
+      cleanReports.Count);
+
+    foreach (var report in cleanReports)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      try
+      {
+        await processor.ProcessReportAsync(report.Id, cancellationToken: cancellationToken);
+      }
+      catch (Exception ex) when (ex is not OperationCanceledException)
+      {
+        logger.LogError(
+          ex,
+          "Failed to process report {ReportId} during extraction cycle.",
+          report.Id);
+      }
+    }
+  }
+}

--- a/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportService.cs
@@ -222,6 +222,22 @@ internal sealed class ReportService(
         parameter.IsAbnormal))
       .ToArray();
 
+    ExtractionStatusResponse? extraction = null;
+    if (report.Extraction is not null)
+    {
+      extraction = new ExtractionStatusResponse(
+        report.Id,
+        ToStatusString(report.Status),
+        report.Extraction.ExtractionMethod,
+        report.Extraction.StructuringModel,
+        report.Extraction.ExtractedParameterCount,
+        report.Extraction.OverallConfidence,
+        report.Extraction.PageCount,
+        report.Extraction.ExtractedAt,
+        report.Extraction.ErrorMessage,
+        report.Extraction.AttemptCount);
+    }
+
     return new ReportDetailResponse(
       report.Id,
       report.ReportNumber,
@@ -235,7 +251,8 @@ internal sealed class ReportService(
       report.ReportedAt,
       report.Results.Notes,
       parameters,
-      download);
+      download,
+      extraction);
   }
 
   public async Task<ReportSummaryResponse> AddForUserAsync(

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -55,6 +55,8 @@ internal static class V1FeatureServiceCollectionExtensions
     services.AddKeyedScoped<ITextExtractionProvider, TextractTextExtractionProvider>("textract");
     services.AddScoped<IReportParameterExtractor, LlmReportParameterExtractor>();
     services.AddScoped<IReportPdfExtractionProcessor, ReportPdfExtractionProcessor>();
+    services.AddScoped<IReportExtractionService, ReportExtractionService>();
+    services.AddHostedService<ReportPdfExtractionHostedService>();
 
     return services;
   }

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -128,6 +128,11 @@ builder.Services
   .ValidateDataAnnotations();
 
 builder.Services
+  .AddOptionsWithValidateOnStart<PdfExtractionOptions>()
+  .BindConfiguration(PdfExtractionOptions.SectionName)
+  .ValidateDataAnnotations();
+
+builder.Services
   .AddOptionsWithValidateOnStart<VirusScanningOptions>()
   .BindConfiguration(VirusScanningOptions.SectionName)
   .ValidateDataAnnotations();
@@ -235,6 +240,7 @@ builder.Services.AddAarogyaAuthorization();
 builder.Services.AddAarogyaCorsPolicy(builder.Configuration);
 builder.Services.AddAarogyaSecurityHeaders(builder.Configuration);
 builder.Services.AddV1FeatureServices();
+builder.Services.AddLlmChatClient(builder.Configuration);
 
 var rateLimitingOptions = builder.Configuration
   .GetSection(RateLimitingOptions.SectionName)

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -133,6 +133,21 @@
     "QuarantinePrefix": "quarantine",
     "DefinitionsRefreshIntervalMinutes": 60
   },
+  "PdfExtraction": {
+    "EnableExtraction": true,
+    "EnableAutoExtractionWorker": true,
+    "WorkerIntervalMinutes": 2,
+    "BatchSize": 5,
+    "MinTextLengthPerPage": 50,
+    "MaxRetryAttempts": 3,
+    "LlmProvider": "ollama",
+    "OllamaEndpoint": "http://10.0.10.113:11434",
+    "OllamaModelId": "qwen2.5:14b-instruct",
+    "BedrockModelId": "anthropic.claude-sonnet-4-20250514",
+    "MaxTokens": 4096,
+    "MinConfidenceThreshold": 0.5,
+    "StoreRawExtractedText": true
+  },
   "FileDeletion": {
     "EnableHardDeleteWorker": true,
     "RetentionDays": 2555,

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -216,6 +216,21 @@
     "QuarantinePrefix": "quarantine",
     "DefinitionsRefreshIntervalMinutes": 60
   },
+  "PdfExtraction": {
+    "EnableExtraction": true,
+    "EnableAutoExtractionWorker": true,
+    "WorkerIntervalMinutes": 2,
+    "BatchSize": 10,
+    "MinTextLengthPerPage": 50,
+    "MaxRetryAttempts": 3,
+    "LlmProvider": "bedrock",
+    "OllamaEndpoint": "http://localhost:11434",
+    "OllamaModelId": "qwen2.5:14b-instruct",
+    "BedrockModelId": "anthropic.claude-sonnet-4-20250514",
+    "MaxTokens": 4096,
+    "MinConfidenceThreshold": 0.5,
+    "StoreRawExtractedText": false
+  },
   "FileDeletion": {
     "EnableHardDeleteWorker": true,
     "RetentionDays": 2555,

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportExtractionServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportExtractionServiceTests.cs
@@ -1,0 +1,267 @@
+using Aarogya.Api.Authentication;
+using Aarogya.Api.Features.V1.Reports;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+using Aarogya.Domain.ValueObjects;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Features.V1.Reports;
+
+public sealed class ReportExtractionServiceTests
+{
+  private readonly Mock<IUserRepository> _userRepository = new();
+  private readonly Mock<IReportRepository> _reportRepository = new();
+  private readonly Mock<IAccessGrantRepository> _accessGrantRepository = new();
+  private readonly Mock<IReportPdfExtractionProcessor> _processor = new();
+  private readonly Mock<IUtcClock> _clock = new();
+  private readonly ReportExtractionService _sut;
+
+  private static readonly Guid UserId = Guid.NewGuid();
+  private static readonly Guid ReportId = Guid.NewGuid();
+  private const string UserSub = "test-user-sub";
+
+  public ReportExtractionServiceTests()
+  {
+    _clock.Setup(x => x.UtcNow).Returns(DateTimeOffset.UtcNow);
+    _sut = new ReportExtractionService(
+      _userRepository.Object,
+      _reportRepository.Object,
+      _accessGrantRepository.Object,
+      _processor.Object,
+      _clock.Object);
+  }
+
+  [Fact]
+  public async Task GetExtractionStatusAsync_ShouldThrow_WhenUserNotFoundAsync()
+  {
+    _userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync(UserSub, It.IsAny<CancellationToken>()))
+      .ReturnsAsync((User?)null);
+
+    var act = () => _sut.GetExtractionStatusAsync(UserSub, ReportId);
+
+    await act.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*not provisioned*");
+  }
+
+  [Fact]
+  public async Task GetExtractionStatusAsync_ShouldThrow_WhenReportNotFoundAsync()
+  {
+    SetupUser(UserRole.Patient);
+    _reportRepository
+      .Setup(x => x.FirstOrDefaultAsync(
+        It.IsAny<ReportByIdSpecification>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync((Report?)null);
+
+    var act = () => _sut.GetExtractionStatusAsync(UserSub, ReportId);
+
+    await act.Should().ThrowAsync<KeyNotFoundException>()
+      .WithMessage("*not found*");
+  }
+
+  [Fact]
+  public async Task GetExtractionStatusAsync_ShouldThrow_WhenPatientDoesNotOwnReportAsync()
+  {
+    SetupUser(UserRole.Patient);
+    SetupReport(patientId: Guid.NewGuid());
+
+    var act = () => _sut.GetExtractionStatusAsync(UserSub, ReportId);
+
+    await act.Should().ThrowAsync<UnauthorizedAccessException>()
+      .WithMessage("*do not have access*");
+  }
+
+  [Fact]
+  public async Task GetExtractionStatusAsync_ShouldReturnNull_WhenNoExtractionMetadataAsync()
+  {
+    var user = SetupUser(UserRole.Patient);
+    SetupReport(patientId: user.Id, extraction: null);
+
+    var result = await _sut.GetExtractionStatusAsync(UserSub, ReportId);
+
+    result.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task GetExtractionStatusAsync_ShouldReturnStatus_WhenExtractionExistsAsync()
+  {
+    var user = SetupUser(UserRole.Patient);
+    var extraction = new ExtractionMetadata
+    {
+      ExtractionMethod = "pdfpig",
+      StructuringModel = "test-model",
+      ExtractedParameterCount = 5,
+      OverallConfidence = 0.85,
+      PageCount = 2,
+      ExtractedAt = DateTimeOffset.UtcNow,
+      AttemptCount = 1
+    };
+    SetupReport(patientId: user.Id, extraction: extraction, status: ReportStatus.Extracted);
+
+    var result = await _sut.GetExtractionStatusAsync(UserSub, ReportId);
+
+    result.Should().NotBeNull();
+    result!.ReportId.Should().Be(ReportId);
+    result.ExtractionMethod.Should().Be("pdfpig");
+    result.ExtractedParameterCount.Should().Be(5);
+    result.OverallConfidence.Should().Be(0.85);
+  }
+
+  [Fact]
+  public async Task GetExtractionStatusAsync_ShouldAllowLabTech_WhenUploadedByThemAsync()
+  {
+    var user = SetupUser(UserRole.LabTechnician);
+    var extraction = new ExtractionMetadata { ExtractionMethod = "pdfpig", AttemptCount = 1 };
+    SetupReport(uploadedByUserId: user.Id, extraction: extraction, status: ReportStatus.Extracted);
+
+    var result = await _sut.GetExtractionStatusAsync(UserSub, ReportId);
+
+    result.Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task GetExtractionStatusAsync_ShouldAllowDoctor_WhenHasActiveGrantAsync()
+  {
+    var user = SetupUser(UserRole.Doctor);
+    var patientId = Guid.NewGuid();
+    var extraction = new ExtractionMetadata { ExtractionMethod = "pdfpig", AttemptCount = 1 };
+    SetupReport(patientId: patientId, extraction: extraction, status: ReportStatus.Extracted);
+
+    var grant = new AccessGrant { PatientId = patientId, GrantedToUserId = user.Id };
+    _accessGrantRepository
+      .Setup(x => x.ListAsync(
+        It.IsAny<ActiveAccessGrantsForDoctorSpecification>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync([grant]);
+
+    var result = await _sut.GetExtractionStatusAsync(UserSub, ReportId);
+
+    result.Should().NotBeNull();
+  }
+
+  [Fact]
+  public async Task TriggerExtractionAsync_ShouldThrow_WhenNoUploadedFileAsync()
+  {
+    var user = SetupUser(UserRole.Patient);
+    SetupReport(patientId: user.Id, fileStorageKey: null);
+
+    var act = () => _sut.TriggerExtractionAsync(UserSub, ReportId);
+
+    await act.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*no uploaded file*");
+  }
+
+  [Fact]
+  public async Task TriggerExtractionAsync_ShouldThrow_WhenStatusNotAllowedAsync()
+  {
+    var user = SetupUser(UserRole.Patient);
+    SetupReport(patientId: user.Id, status: ReportStatus.Extracting);
+
+    var act = () => _sut.TriggerExtractionAsync(UserSub, ReportId);
+
+    await act.Should().ThrowAsync<InvalidOperationException>()
+      .WithMessage("*cannot be extracted*");
+  }
+
+  [Fact]
+  public async Task TriggerExtractionAsync_ShouldCallProcessor_WhenStatusCleanAsync()
+  {
+    var user = SetupUser(UserRole.Patient);
+    SetupReport(patientId: user.Id, status: ReportStatus.Clean);
+
+    _processor
+      .Setup(x => x.ProcessReportAsync(
+        ReportId,
+        false,
+        It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    await _sut.TriggerExtractionAsync(UserSub, ReportId);
+
+    _processor.Verify(
+      x => x.ProcessReportAsync(ReportId, false, It.IsAny<CancellationToken>()),
+      Times.Once);
+  }
+
+  [Fact]
+  public async Task TriggerExtractionAsync_ShouldCallProcessor_WhenStatusExtractionFailedAsync()
+  {
+    var user = SetupUser(UserRole.Patient);
+    SetupReport(patientId: user.Id, status: ReportStatus.ExtractionFailed);
+
+    _processor
+      .Setup(x => x.ProcessReportAsync(
+        ReportId,
+        false,
+        It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    await _sut.TriggerExtractionAsync(UserSub, ReportId);
+
+    _processor.Verify(
+      x => x.ProcessReportAsync(ReportId, false, It.IsAny<CancellationToken>()),
+      Times.Once);
+  }
+
+  [Fact]
+  public async Task TriggerExtractionAsync_ShouldAllow_WhenForceReprocessOnExtractedStatusAsync()
+  {
+    var user = SetupUser(UserRole.Patient);
+    SetupReport(patientId: user.Id, status: ReportStatus.Extracted);
+
+    _processor
+      .Setup(x => x.ProcessReportAsync(
+        ReportId,
+        true,
+        It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    await _sut.TriggerExtractionAsync(UserSub, ReportId, forceReprocess: true);
+
+    _processor.Verify(
+      x => x.ProcessReportAsync(ReportId, true, It.IsAny<CancellationToken>()),
+      Times.Once);
+  }
+
+  private User SetupUser(UserRole role)
+  {
+    var user = new User
+    {
+      Id = UserId,
+      ExternalAuthId = UserSub,
+      Role = role
+    };
+    _userRepository
+      .Setup(x => x.GetByExternalAuthIdAsync(UserSub, It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
+    return user;
+  }
+
+  private void SetupReport(
+    Guid? patientId = null,
+    Guid? uploadedByUserId = null,
+    ExtractionMetadata? extraction = null,
+    ReportStatus status = ReportStatus.Clean,
+    string? fileStorageKey = "test-key.pdf")
+  {
+    var report = new Report
+    {
+      Id = ReportId,
+      PatientId = patientId ?? Guid.NewGuid(),
+      UploadedByUserId = uploadedByUserId ?? Guid.NewGuid(),
+      Status = status,
+      FileStorageKey = fileStorageKey,
+      Extraction = extraction
+    };
+    _reportRepository
+      .Setup(x => x.FirstOrDefaultAsync(
+        It.IsAny<ReportByIdSpecification>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync(report);
+  }
+}

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportPdfExtractionHostedServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportPdfExtractionHostedServiceTests.cs
@@ -1,0 +1,216 @@
+using Aarogya.Api.Features.V1.Reports;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Aarogya.Domain.Specifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests.Features.V1.Reports;
+
+public sealed class ReportPdfExtractionHostedServiceTests
+{
+  [Fact]
+  public async Task ExecuteAsync_ShouldReturnImmediately_WhenWorkerDisabledAsync()
+  {
+    var scopeFactory = new Mock<IServiceScopeFactory>();
+    var options = Options.Create(new PdfExtractionOptions { EnableAutoExtractionWorker = false });
+
+    var sut = new ReportPdfExtractionHostedService(
+      scopeFactory.Object,
+      options,
+      NullLogger<ReportPdfExtractionHostedService>.Instance);
+
+    using var cts = new CancellationTokenSource();
+    await sut.StartAsync(cts.Token);
+    await Task.Delay(100);
+    await cts.CancelAsync();
+    await sut.StopAsync(CancellationToken.None);
+
+    scopeFactory.Verify(
+      x => x.CreateScope(),
+      Times.Never);
+  }
+
+  [Fact]
+  public async Task ExecuteAsync_ShouldProcessCleanReports_WhenWorkerEnabledAsync()
+  {
+    var reportId = Guid.NewGuid();
+    var report = new Report { Id = reportId, Status = ReportStatus.Clean, FileStorageKey = "test.pdf" };
+
+    var reportRepository = new Mock<IReportRepository>();
+    reportRepository
+      .Setup(x => x.ListAsync(
+        It.IsAny<CleanReportsAwaitingExtractionSpecification>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync([report]);
+
+    var processor = new Mock<IReportPdfExtractionProcessor>();
+    processor
+      .Setup(x => x.ProcessReportAsync(
+        reportId,
+        It.IsAny<bool>(),
+        It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    var serviceProvider = new Mock<IServiceProvider>();
+    serviceProvider
+      .Setup(x => x.GetService(typeof(IReportRepository)))
+      .Returns(reportRepository.Object);
+    serviceProvider
+      .Setup(x => x.GetService(typeof(IReportPdfExtractionProcessor)))
+      .Returns(processor.Object);
+
+    var scope = new Mock<IServiceScope>();
+    scope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+
+    var scopeFactory = new Mock<IServiceScopeFactory>();
+    scopeFactory
+      .Setup(x => x.CreateScope())
+      .Returns(scope.Object);
+
+    var options = Options.Create(new PdfExtractionOptions
+    {
+      EnableAutoExtractionWorker = true,
+      WorkerIntervalMinutes = 60,
+      BatchSize = 10
+    });
+
+    var sut = new ReportPdfExtractionHostedService(
+      scopeFactory.Object,
+      options,
+      NullLogger<ReportPdfExtractionHostedService>.Instance);
+
+    using var cts = new CancellationTokenSource();
+    await sut.StartAsync(cts.Token);
+    await Task.Delay(200);
+    await cts.CancelAsync();
+    await sut.StopAsync(CancellationToken.None);
+
+    processor.Verify(
+      x => x.ProcessReportAsync(reportId, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+      Times.AtLeastOnce);
+  }
+
+  [Fact]
+  public async Task ExecuteAsync_ShouldNotCallProcessor_WhenNoCleanReportsAsync()
+  {
+    var reportRepository = new Mock<IReportRepository>();
+    reportRepository
+      .Setup(x => x.ListAsync(
+        It.IsAny<CleanReportsAwaitingExtractionSpecification>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync([]);
+
+    var processor = new Mock<IReportPdfExtractionProcessor>();
+
+    var serviceProvider = new Mock<IServiceProvider>();
+    serviceProvider
+      .Setup(x => x.GetService(typeof(IReportRepository)))
+      .Returns(reportRepository.Object);
+    serviceProvider
+      .Setup(x => x.GetService(typeof(IReportPdfExtractionProcessor)))
+      .Returns(processor.Object);
+
+    var scope = new Mock<IServiceScope>();
+    scope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+
+    var scopeFactory = new Mock<IServiceScopeFactory>();
+    scopeFactory
+      .Setup(x => x.CreateScope())
+      .Returns(scope.Object);
+
+    var options = Options.Create(new PdfExtractionOptions
+    {
+      EnableAutoExtractionWorker = true,
+      WorkerIntervalMinutes = 60,
+      BatchSize = 5
+    });
+
+    var sut = new ReportPdfExtractionHostedService(
+      scopeFactory.Object,
+      options,
+      NullLogger<ReportPdfExtractionHostedService>.Instance);
+
+    using var cts = new CancellationTokenSource();
+    await sut.StartAsync(cts.Token);
+    await Task.Delay(200);
+    await cts.CancelAsync();
+    await sut.StopAsync(CancellationToken.None);
+
+    processor.Verify(
+      x => x.ProcessReportAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+      Times.Never);
+  }
+
+  [Fact]
+  public async Task ExecuteAsync_ShouldContinueProcessing_WhenSingleReportFailsAsync()
+  {
+    var reportId1 = Guid.NewGuid();
+    var reportId2 = Guid.NewGuid();
+    var report1 = new Report { Id = reportId1, Status = ReportStatus.Clean, FileStorageKey = "test1.pdf" };
+    var report2 = new Report { Id = reportId2, Status = ReportStatus.Clean, FileStorageKey = "test2.pdf" };
+
+    var reportRepository = new Mock<IReportRepository>();
+    reportRepository
+      .Setup(x => x.ListAsync(
+        It.IsAny<CleanReportsAwaitingExtractionSpecification>(),
+        It.IsAny<CancellationToken>()))
+      .ReturnsAsync([report1, report2]);
+
+    var processor = new Mock<IReportPdfExtractionProcessor>();
+    processor
+      .Setup(x => x.ProcessReportAsync(
+        reportId1,
+        It.IsAny<bool>(),
+        It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new InvalidOperationException("Extraction failed"));
+    processor
+      .Setup(x => x.ProcessReportAsync(
+        reportId2,
+        It.IsAny<bool>(),
+        It.IsAny<CancellationToken>()))
+      .Returns(Task.CompletedTask);
+
+    var serviceProvider = new Mock<IServiceProvider>();
+    serviceProvider
+      .Setup(x => x.GetService(typeof(IReportRepository)))
+      .Returns(reportRepository.Object);
+    serviceProvider
+      .Setup(x => x.GetService(typeof(IReportPdfExtractionProcessor)))
+      .Returns(processor.Object);
+
+    var scope = new Mock<IServiceScope>();
+    scope.Setup(x => x.ServiceProvider).Returns(serviceProvider.Object);
+
+    var scopeFactory = new Mock<IServiceScopeFactory>();
+    scopeFactory
+      .Setup(x => x.CreateScope())
+      .Returns(scope.Object);
+
+    var options = Options.Create(new PdfExtractionOptions
+    {
+      EnableAutoExtractionWorker = true,
+      WorkerIntervalMinutes = 60,
+      BatchSize = 10
+    });
+
+    var sut = new ReportPdfExtractionHostedService(
+      scopeFactory.Object,
+      options,
+      NullLogger<ReportPdfExtractionHostedService>.Instance);
+
+    using var cts = new CancellationTokenSource();
+    await sut.StartAsync(cts.Token);
+    await Task.Delay(200);
+    await cts.CancelAsync();
+    await sut.StopAsync(CancellationToken.None);
+
+    processor.Verify(
+      x => x.ProcessReportAsync(reportId2, It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+      Times.AtLeastOnce);
+  }
+}

--- a/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/ReportsControllerTests.cs
@@ -391,7 +391,9 @@ public sealed class ReportsControllerTests
         It.IsAny<CancellationToken>()))
       .Returns(Task.CompletedTask);
 
-    return new ReportsController(reportService, uploadService, checksumService, consentService.Object)
+    var extractionService = new Mock<IReportExtractionService>();
+
+    return new ReportsController(reportService, uploadService, checksumService, extractionService.Object, consentService.Object)
     {
       ControllerContext = new ControllerContext
       {


### PR DESCRIPTION
## Summary
- Add `ReportPdfExtractionHostedService` background worker that polls for `Clean` reports and processes them through the PDF extraction pipeline (text extraction → LLM structuring → parameter persistence)
- Add `GET api/v1/reports/{id}/extraction` and `POST api/v1/reports/{id}/extract` endpoints to `ReportsController` with role-based access control (Patient owns report, LabTech uploaded it, Doctor has active grant)
- Add `IReportExtractionService` / `ReportExtractionService` with authorization checks and extraction trigger validation (status must be Clean or ExtractionFailed, or forceReprocess=true)
- Register `PdfExtractionOptions` configuration in `Program.cs` with validation-on-start
- Register `AddLlmChatClient` (Ollama for dev, Bedrock for prod) and hosted service in DI
- Add `PdfExtraction` config section to `appsettings.json` (Bedrock) and `appsettings.Development.json` (Ollama on quasar)
- Add `ExtractionStatusResponse` and `TriggerExtractionRequest` contracts; extend `ReportDetailResponse` with optional extraction metadata
- 16 new tests covering hosted service lifecycle (disabled/enabled/empty batch/error resilience) and extraction service (access control, status validation, trigger flow)

Closes #225

## Test plan
- [x] `dotnet build` passes with 0 errors
- [x] `dotnet test` — all 569 tests pass (459 API + 69 Domain + 41 Infrastructure)
- [x] `dotnet format --verify-no-changes` passes (exit code 0)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)