### PR TITLE
fix(extraction): remove redundant Update calls causing DbUpdateConcurrencyException

### DIFF
--- a/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
@@ -72,7 +72,6 @@ internal sealed class ReportPdfExtractionProcessor(
     try
     {
       report.Status = ReportStatus.Extracting;
-      reportRepository.Update(report);
       await unitOfWork.SaveChangesAsync(cancellationToken);
 
       var textResult = await ExtractTextAsync(report, options, cancellationToken);
@@ -96,7 +95,6 @@ internal sealed class ReportPdfExtractionProcessor(
         logger.LogWarning("No text extracted from report {ReportId}", reportId);
         report.Status = ReportStatus.ExtractionFailed;
         report.Extraction.ErrorMessage = "No text could be extracted from the PDF.";
-        reportRepository.Update(report);
         await unitOfWork.SaveChangesAsync(cancellationToken);
         return;
       }
@@ -122,7 +120,6 @@ internal sealed class ReportPdfExtractionProcessor(
       report.Status = ReportStatus.Extracted;
       report.Extraction.ErrorMessage = null;
 
-      reportRepository.Update(report);
       await unitOfWork.SaveChangesAsync(cancellationToken);
 
       logger.LogInformation(
@@ -142,7 +139,6 @@ internal sealed class ReportPdfExtractionProcessor(
       report.Status = ReportStatus.ExtractionFailed;
       report.Extraction.ErrorMessage = ex.Message;
 
-      reportRepository.Update(report);
       await unitOfWork.SaveChangesAsync(cancellationToken);
     }
   }

--- a/src/Aarogya.Domain/Specifications/CleanReportsAwaitingExtractionSpecification.cs
+++ b/src/Aarogya.Domain/Specifications/CleanReportsAwaitingExtractionSpecification.cs
@@ -13,5 +13,6 @@ public sealed class CleanReportsAwaitingExtractionSpecification : BaseSpecificat
   {
     ApplyOrderBy(report => report.UpdatedAt);
     ApplyPaging(0, batchSize);
+    ApplyAsNoTracking();
   }
 }


### PR DESCRIPTION
## Summary
- Remove redundant `reportRepository.Update(report)` calls in `ReportPdfExtractionProcessor` that caused `DbUpdateConcurrencyException` during extraction
- `DbSet.Update()` recursively sets ALL reachable entities to `Modified` state — when newly added `ReportParameter` entities were present, they were marked as Modified instead of Added, causing EF Core to emit UPDATE (affecting 0 rows) instead of INSERT
- Add `ApplyAsNoTracking()` to `CleanReportsAwaitingExtractionSpecification` since the hosted service only needs report IDs (the processor re-loads each report independently with tracking)

## Test plan
- [x] All 569 existing tests pass
- [x] Format check passes
- [ ] Deploy to dev server, reset test report to `clean`, verify extraction completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)