### PR TITLE
fix(extraction): let EF Core generate ReportParameter IDs to fix entity state

### DIFF
--- a/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
@@ -218,7 +218,6 @@ internal sealed class ReportPdfExtractionProcessor(
 
       report.Parameters.Add(new ReportParameter
       {
-        Id = Guid.NewGuid(),
         ReportId = report.Id,
         ParameterCode = param.Code,
         ParameterName = param.Name,


### PR DESCRIPTION
## Summary
- Remove explicit `Id = Guid.NewGuid()` from new `ReportParameter` entities in the extraction processor
- When entities are added to a tracked navigation collection, EF Core's `DetectChanges()` uses the primary key to determine state: `Guid.Empty` = Added (INSERT), non-default = Modified (UPDATE)
- Setting the ID pre-emptively caused EF Core to emit UPDATE instead of INSERT, resulting in `DbUpdateConcurrencyException` (0 rows affected for non-existent rows)
- Let EF Core's `ValueGeneratedOnAdd` handle GUID generation automatically

## Root cause
This was the actual root cause of the extraction failure discovered after PR #230 (which removed redundant `Update()` calls). The combination of both fixes is needed.

## Test plan
- [x] All 569 existing tests pass
- [ ] Deploy to dev server, reset test report, verify extraction completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)