### PR TITLE
fix(reports): handle null Messages in SQS consumer to prevent NRE

### DIFF
--- a/src/Aarogya.Api/Features/V1/Reports/S3UploadEventConsumerHostedService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/S3UploadEventConsumerHostedService.cs
@@ -70,7 +70,7 @@ internal sealed class S3UploadEventConsumerHostedService(
       VisibilityTimeout = sqsOptions.VisibilityTimeoutSeconds
     }, cancellationToken);
 
-    if (receive.Messages.Count == 0)
+    if (receive.Messages is not { Count: > 0 })
     {
       await Task.Delay(sqsOptions.EmptyPollDelayMilliseconds, cancellationToken);
       return;


### PR DESCRIPTION
## Summary
- LocalStack SQS can return `null` for the `Messages` list instead of an empty list
- This caused a `NullReferenceException` in `PollQueueAsync` every poll cycle (~10s), flooding pod logs
- Changed `receive.Messages.Count == 0` to `receive.Messages is not { Count: > 0 }` for null-safe handling

## Test plan
- [x] All 500 tests pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Deploy and verify pod logs no longer show NRE spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)