### PR TITLE
feat(auth): add user auto-provisioning on first login

### DIFF
--- a/src/Aarogya.Api/Authentication/UserAutoProvisioningMiddleware.cs
+++ b/src/Aarogya.Api/Authentication/UserAutoProvisioningMiddleware.cs
@@ -1,0 +1,18 @@
+namespace Aarogya.Api.Authentication;
+
+internal sealed class UserAutoProvisioningMiddleware(RequestDelegate next)
+{
+  public async Task InvokeAsync(HttpContext context)
+  {
+    if (context.User.Identity?.IsAuthenticated == true)
+    {
+      var provisioningService = context.RequestServices.GetService<IUserAutoProvisioningService>();
+      if (provisioningService is not null)
+      {
+        await provisioningService.EnsureUserExistsAsync(context.User, context.RequestAborted);
+      }
+    }
+
+    await next(context);
+  }
+}

--- a/src/Aarogya.Api/Authentication/UserAutoProvisioningService.cs
+++ b/src/Aarogya.Api/Authentication/UserAutoProvisioningService.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using Aarogya.Api.Caching;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+
+namespace Aarogya.Api.Authentication;
+
+[SuppressMessage(
+  "Performance",
+  "CA1515:Consider making public types internal",
+  Justification = "Resolved from DI in middleware via RequestServices.")]
+public interface IUserAutoProvisioningService
+{
+  public Task EnsureUserExistsAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default);
+}
+
+internal sealed class UserAutoProvisioningService(
+  IUserRepository userRepository,
+  IUnitOfWork unitOfWork,
+  IEntityCacheService cacheService,
+  ILogger<UserAutoProvisioningService> logger)
+  : IUserAutoProvisioningService
+{
+  private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+  private const string CacheKeyPrefix = "user_exists:";
+
+  public async Task EnsureUserExistsAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default)
+  {
+    var sub = principal.FindFirstValue("sub");
+    if (string.IsNullOrWhiteSpace(sub))
+    {
+      return;
+    }
+
+    if (sub.StartsWith("lab:", StringComparison.Ordinal))
+    {
+      return;
+    }
+
+    var cacheKey = string.Concat(CacheKeyPrefix, sub);
+    var cached = await cacheService.GetAsync<bool>(cacheKey, cancellationToken);
+    if (cached)
+    {
+      return;
+    }
+
+    var existingUser = await userRepository.GetByExternalAuthIdAsync(sub, cancellationToken);
+    if (existingUser is not null)
+    {
+      await cacheService.SetAsync(cacheKey, true, CacheTtl, cancellationToken);
+      return;
+    }
+
+    var email = principal.FindFirstValue("email") ?? string.Empty;
+    var givenName = principal.FindFirstValue("given_name") ?? string.Empty;
+    var familyName = principal.FindFirstValue("family_name") ?? string.Empty;
+
+    var user = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = sub,
+      Role = UserRole.Patient,
+      FirstName = !string.IsNullOrWhiteSpace(givenName) ? givenName : "User",
+      LastName = !string.IsNullOrWhiteSpace(familyName) ? familyName : sub[..Math.Min(sub.Length, 8)],
+      Email = !string.IsNullOrWhiteSpace(email) ? email : $"{sub}@placeholder.local",
+      IsActive = true
+    };
+
+    await userRepository.AddAsync(user, cancellationToken);
+    await unitOfWork.SaveChangesAsync(cancellationToken);
+
+    logger.LogInformation("Auto-provisioned user {Sub} with role {Role}", sub, UserRole.Patient);
+    await cacheService.SetAsync(cacheKey, true, CacheTtl, cancellationToken);
+  }
+}

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -193,6 +193,7 @@ builder.Services.AddSingleton<ICognitoSocialTokenClient, CognitoOAuthTokenClient
 builder.Services.AddSingleton<ISocialAuthService, CognitoSocialAuthService>();
 builder.Services.AddSingleton<ICognitoTokenManagementService, CognitoTokenManagementService>();
 builder.Services.AddSingleton<IRoleAssignmentService, InMemoryRoleAssignmentService>();
+builder.Services.AddScoped<IUserAutoProvisioningService, UserAutoProvisioningService>();
 builder.Services.AddScoped<IAuditLoggingService, AuditLoggingService>();
 builder.Services.AddHostedService<DataEncryptionKeyRotationHostedService>();
 builder.Services.AddHostedService<BreachDetectionHostedService>();
@@ -282,6 +283,7 @@ if (!app.Environment.IsDevelopment())
 app.UseCors("AarogyaPolicy");
 app.UseResponseCaching();
 app.UseAuthentication();
+app.UseMiddleware<UserAutoProvisioningMiddleware>();
 if (rateLimitingOptions.EnableRateLimiting)
 {
   app.UseRateLimiter();

--- a/tests/Aarogya.Api.Tests/UserAutoProvisioningMiddlewareTests.cs
+++ b/tests/Aarogya.Api.Tests/UserAutoProvisioningMiddlewareTests.cs
@@ -1,0 +1,98 @@
+using System.Security.Claims;
+using Aarogya.Api.Authentication;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class UserAutoProvisioningMiddlewareTests
+{
+  [Fact]
+  public async Task InvokeAsync_ShouldCallService_WhenAuthenticatedAsync()
+  {
+    var provisioningService = new Mock<IUserAutoProvisioningService>();
+    var serviceProvider = new Mock<IServiceProvider>();
+    serviceProvider.Setup(sp => sp.GetService(typeof(IUserAutoProvisioningService)))
+      .Returns(provisioningService.Object);
+
+    var httpContext = new DefaultHttpContext
+    {
+      User = new ClaimsPrincipal(new ClaimsIdentity(
+      [
+        new Claim("sub", "user-123")
+      ], "TestAuth")),
+      RequestServices = serviceProvider.Object
+    };
+
+    var nextCalled = false;
+    var middleware = new UserAutoProvisioningMiddleware(_ =>
+    {
+      nextCalled = true;
+      return Task.CompletedTask;
+    });
+
+    await middleware.InvokeAsync(httpContext);
+
+    provisioningService.Verify(s => s.EnsureUserExistsAsync(
+      It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()), Times.Once);
+    nextCalled.Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task InvokeAsync_ShouldSkipService_WhenUnauthenticatedAsync()
+  {
+    var provisioningService = new Mock<IUserAutoProvisioningService>();
+    var serviceProvider = new Mock<IServiceProvider>();
+    serviceProvider.Setup(sp => sp.GetService(typeof(IUserAutoProvisioningService)))
+      .Returns(provisioningService.Object);
+
+    var httpContext = new DefaultHttpContext
+    {
+      User = new ClaimsPrincipal(new ClaimsIdentity()),
+      RequestServices = serviceProvider.Object
+    };
+
+    var nextCalled = false;
+    var middleware = new UserAutoProvisioningMiddleware(_ =>
+    {
+      nextCalled = true;
+      return Task.CompletedTask;
+    });
+
+    await middleware.InvokeAsync(httpContext);
+
+    provisioningService.Verify(s => s.EnsureUserExistsAsync(
+      It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()), Times.Never);
+    nextCalled.Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task InvokeAsync_ShouldContinue_WhenServiceNotRegisteredAsync()
+  {
+    var serviceProvider = new Mock<IServiceProvider>();
+    serviceProvider.Setup(sp => sp.GetService(typeof(IUserAutoProvisioningService)))
+      .Returns(null!);
+
+    var httpContext = new DefaultHttpContext
+    {
+      User = new ClaimsPrincipal(new ClaimsIdentity(
+      [
+        new Claim("sub", "user-123")
+      ], "TestAuth")),
+      RequestServices = serviceProvider.Object
+    };
+
+    var nextCalled = false;
+    var middleware = new UserAutoProvisioningMiddleware(_ =>
+    {
+      nextCalled = true;
+      return Task.CompletedTask;
+    });
+
+    await middleware.InvokeAsync(httpContext);
+
+    nextCalled.Should().BeTrue();
+  }
+}

--- a/tests/Aarogya.Api.Tests/UserAutoProvisioningServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/UserAutoProvisioningServiceTests.cs
@@ -1,0 +1,151 @@
+using System.Security.Claims;
+using Aarogya.Api.Authentication;
+using Aarogya.Api.Caching;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+public sealed class UserAutoProvisioningServiceTests
+{
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldSkip_WhenCachedAsync()
+  {
+    var (service, repo, uow, cache) = CreateService();
+    cache.Setup(c => c.GetAsync<bool>("user_exists:sub-123", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(true);
+
+    var principal = CreatePrincipal("sub-123", "user@example.com");
+    await service.EnsureUserExistsAsync(principal);
+
+    repo.Verify(r => r.GetByExternalAuthIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldCacheAndReturn_WhenUserExistsInDbAsync()
+  {
+    var (service, repo, uow, cache) = CreateService();
+    cache.Setup(c => c.GetAsync<bool>("user_exists:sub-456", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(false);
+    repo.Setup(r => r.GetByExternalAuthIdAsync("sub-456", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new User { ExternalAuthId = "sub-456" });
+
+    var principal = CreatePrincipal("sub-456", "user@example.com");
+    await service.EnsureUserExistsAsync(principal);
+
+    cache.Verify(c => c.SetAsync("user_exists:sub-456", true, TimeSpan.FromMinutes(5), It.IsAny<CancellationToken>()), Times.Once);
+    uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldCreateUser_WhenNotFoundAsync()
+  {
+    var (service, repo, uow, cache) = CreateService();
+    cache.Setup(c => c.GetAsync<bool>("user_exists:sub-789", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(false);
+    repo.Setup(r => r.GetByExternalAuthIdAsync("sub-789", It.IsAny<CancellationToken>()))
+      .ReturnsAsync((User?)null);
+    repo.Setup(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+    var principal = CreatePrincipal("sub-789", "new@example.com", "Jane", "Doe");
+    await service.EnsureUserExistsAsync(principal);
+
+    repo.Verify(r => r.AddAsync(It.Is<User>(u =>
+      u.ExternalAuthId == "sub-789"
+      && u.Email == "new@example.com"
+      && u.FirstName == "Jane"
+      && u.LastName == "Doe"
+      && u.Role == UserRole.Patient
+      && u.IsActive), It.IsAny<CancellationToken>()), Times.Once);
+    uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    cache.Verify(c => c.SetAsync("user_exists:sub-789", true, TimeSpan.FromMinutes(5), It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldHandleMissingClaims_GracefullyAsync()
+  {
+    var (service, repo, uow, cache) = CreateService();
+    cache.Setup(c => c.GetAsync<bool>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(false);
+    repo.Setup(r => r.GetByExternalAuthIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync((User?)null);
+    repo.Setup(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+    var principal = new ClaimsPrincipal(new ClaimsIdentity(
+    [
+      new Claim("sub", "sub-minimal")
+    ], "TestAuth"));
+
+    await service.EnsureUserExistsAsync(principal);
+
+    repo.Verify(r => r.AddAsync(It.Is<User>(u =>
+      u.ExternalAuthId == "sub-minimal"
+      && u.FirstName == "User"
+      && u.Email.Contains("@placeholder.local")), It.IsAny<CancellationToken>()), Times.Once);
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldSkip_WhenSubMissingAsync()
+  {
+    var (service, repo, _, _) = CreateService();
+
+    var principal = new ClaimsPrincipal(new ClaimsIdentity([], "TestAuth"));
+    await service.EnsureUserExistsAsync(principal);
+
+    repo.Verify(r => r.GetByExternalAuthIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldSkip_WhenApiKeySubjectAsync()
+  {
+    var (service, repo, _, _) = CreateService();
+
+    var principal = CreatePrincipal("lab:partner-1", "lab@example.com");
+    await service.EnsureUserExistsAsync(principal);
+
+    repo.Verify(r => r.GetByExternalAuthIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  private static (UserAutoProvisioningService Service, Mock<IUserRepository> Repo, Mock<IUnitOfWork> Uow, Mock<IEntityCacheService> Cache)
+    CreateService()
+  {
+    var repo = new Mock<IUserRepository>();
+    var uow = new Mock<IUnitOfWork>();
+    var cache = new Mock<IEntityCacheService>();
+    var logger = new Mock<ILogger<UserAutoProvisioningService>>();
+    var service = new UserAutoProvisioningService(repo.Object, uow.Object, cache.Object, logger.Object);
+    return (service, repo, uow, cache);
+  }
+
+  private static ClaimsPrincipal CreatePrincipal(
+    string sub,
+    string email,
+    string? givenName = null,
+    string? familyName = null)
+  {
+    var claims = new List<Claim>
+    {
+      new("sub", sub),
+      new("email", email)
+    };
+
+    if (givenName is not null)
+    {
+      claims.Add(new Claim("given_name", givenName));
+    }
+
+    if (familyName is not null)
+    {
+      claims.Add(new Claim("family_name", familyName));
+    }
+
+    return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `UserAutoProvisioningMiddleware` that runs after `UseAuthentication()` to auto-create users in the database on their first authenticated request
- Add `UserAutoProvisioningService` (scoped) that checks a 5-minute entity cache, falls back to the DB, and provisions a new `Patient` role user from JWT claims (`sub`, `email`, `given_name`, `family_name`) when no record exists
- API-key subjects (`lab:` prefix) are skipped to avoid provisioning non-user identities
- Gracefully handles missing claims with sensible defaults (FirstName="User", placeholder email)

## Test plan
- [x] Unit tests for `UserAutoProvisioningService` (6 tests): cached hit skips DB, DB hit caches, new user created with Patient role, missing claims handled, missing sub skipped, API key subject skipped
- [x] Unit tests for `UserAutoProvisioningMiddleware` (3 tests): authenticated calls service, unauthenticated skips, missing service registration continues
- [x] All 602 tests pass (492 API + 69 Domain + 41 Infrastructure)
- [x] `dotnet format --verify-no-changes` clean
- [ ] Manual: After social login, `GET /api/v1/users/me` returns profile for new user; verify `users` row created with Patient role

🤖 Generated with [Claude Code](https://claude.com/claude-code)