### PR TITLE
feat(auth): DB-backed role mapping and Cognito access token audience fix

### DIFF
--- a/src/Aarogya.Api/Authorization/AarogyaRoleClaimsTransformation.cs
+++ b/src/Aarogya.Api/Authorization/AarogyaRoleClaimsTransformation.cs
@@ -7,13 +7,13 @@ internal sealed class AarogyaRoleClaimsTransformation(IRoleAssignmentService rol
 {
   private static readonly HashSet<string> SupportedRoleNames = new(AarogyaRoles.All, StringComparer.OrdinalIgnoreCase);
 
-  public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+  public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
   {
     ArgumentNullException.ThrowIfNull(principal);
 
     if (principal.Identity is not ClaimsIdentity identity || !identity.IsAuthenticated)
     {
-      return Task.FromResult(principal);
+      return principal;
     }
 
     var tokenRoles = principal.Claims
@@ -23,7 +23,8 @@ internal sealed class AarogyaRoleClaimsTransformation(IRoleAssignmentService rol
       .Select(NormalizeRoleName)
       .Distinct(StringComparer.OrdinalIgnoreCase);
 
-    var assignedRoles = roleAssignmentService.GetAssignedRoles(principal.FindFirstValue("sub") ?? string.Empty);
+    var assignedRoles = await roleAssignmentService.GetAssignedRolesAsync(
+      principal.FindFirstValue("sub") ?? string.Empty);
     var normalizedRoles = tokenRoles
       .Concat(assignedRoles)
       .Where(role => SupportedRoleNames.Contains(role))
@@ -49,7 +50,7 @@ internal sealed class AarogyaRoleClaimsTransformation(IRoleAssignmentService rol
       identity.AddClaim(new Claim(ClaimTypes.Role, role));
     }
 
-    return Task.FromResult(principal);
+    return principal;
   }
 
   private static string NormalizeRoleName(string role)

--- a/src/Aarogya.Api/Authorization/RoleAssignmentService.cs
+++ b/src/Aarogya.Api/Authorization/RoleAssignmentService.cs
@@ -1,5 +1,6 @@
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
 
 namespace Aarogya.Api.Authorization;
 
@@ -9,65 +10,81 @@ namespace Aarogya.Api.Authorization;
   Justification = "Used by public controller constructor injection.")]
 public interface IRoleAssignmentService
 {
-  public bool TryAssignRole(
+  public Task<(bool Success, string Message)> TryAssignRoleAsync(
     string actorSub,
     IReadOnlyCollection<string> actorRoles,
     string targetSub,
     string targetRole,
-    out string message);
+    CancellationToken cancellationToken = default);
 
-  public IReadOnlyCollection<string> GetAssignedRoles(string userSub);
+  public Task<IReadOnlyCollection<string>> GetAssignedRolesAsync(
+    string userSub,
+    CancellationToken cancellationToken = default);
 }
 
-internal sealed class InMemoryRoleAssignmentService : IRoleAssignmentService
+internal sealed class DatabaseRoleAssignmentService(
+  IUserRepository userRepository,
+  IUnitOfWork unitOfWork) : IRoleAssignmentService
 {
-  private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> _userRoles = new(StringComparer.Ordinal);
-
-  public bool TryAssignRole(
+  public async Task<(bool Success, string Message)> TryAssignRoleAsync(
     string actorSub,
     IReadOnlyCollection<string> actorRoles,
     string targetSub,
     string targetRole,
-    out string message)
+    CancellationToken cancellationToken = default)
   {
     if (!actorRoles.Contains(AarogyaRoles.Admin, StringComparer.OrdinalIgnoreCase))
     {
-      message = "Only admins can assign roles.";
-      return false;
+      return (false, "Only admins can assign roles.");
     }
 
     if (!AarogyaRoles.All.Contains(targetRole, StringComparer.OrdinalIgnoreCase))
     {
-      message = "Unknown role.";
-      return false;
+      return (false, "Unknown role.");
     }
 
-    var normalizedRole = AarogyaRoles.All.First(role => string.Equals(role, targetRole, StringComparison.OrdinalIgnoreCase));
+    var normalizedRole = AarogyaRoles.All.First(
+      role => string.Equals(role, targetRole, StringComparison.OrdinalIgnoreCase));
     var isSelfUpdate = string.Equals(actorSub, targetSub, StringComparison.Ordinal);
     var alreadyHasRole = actorRoles.Contains(normalizedRole, StringComparer.OrdinalIgnoreCase);
 
     if (isSelfUpdate && !alreadyHasRole)
     {
-      message = "Cannot escalate your own role.";
-      return false;
+      return (false, "Cannot escalate your own role.");
     }
 
-    var assignedRoles = _userRoles.GetOrAdd(targetSub, _ => new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
-    assignedRoles[normalizedRole] = 0;
+    var user = await userRepository.GetByExternalAuthIdAsync(targetSub, cancellationToken);
+    if (user is null)
+    {
+      return (false, $"User '{targetSub}' not found.");
+    }
 
-    message = $"Role '{normalizedRole}' assigned to user '{targetSub}'.";
-    return true;
+    if (!Enum.TryParse<UserRole>(normalizedRole, ignoreCase: true, out var parsedRole))
+    {
+      return (false, $"Role '{normalizedRole}' cannot be mapped to a valid user role.");
+    }
+
+    user.Role = parsedRole;
+    await unitOfWork.SaveChangesAsync(cancellationToken);
+
+    return (true, $"Role '{normalizedRole}' assigned to user '{targetSub}'.");
   }
 
-  public IReadOnlyCollection<string> GetAssignedRoles(string userSub)
+  public async Task<IReadOnlyCollection<string>> GetAssignedRolesAsync(
+    string userSub,
+    CancellationToken cancellationToken = default)
   {
     if (string.IsNullOrWhiteSpace(userSub))
     {
-      return Array.Empty<string>();
+      return [];
     }
 
-    return _userRoles.TryGetValue(userSub, out var roles)
-      ? roles.Keys.ToArray()
-      : Array.Empty<string>();
+    var user = await userRepository.GetByExternalAuthIdAsync(userSub, cancellationToken);
+    if (user is null)
+    {
+      return [];
+    }
+
+    return [user.Role.ToString()];
   }
 }

--- a/src/Aarogya.Api/Configuration/AuthenticationExtensions.cs
+++ b/src/Aarogya.Api/Configuration/AuthenticationExtensions.cs
@@ -77,12 +77,30 @@ public static class AuthenticationExtensions
         options.Authority = issuer;
         options.RequireHttpsMetadata = ShouldRequireHttpsMetadata(awsOptions, issuer);
 
+        var expectedClientId = awsOptions.Cognito.AppClientId;
         options.TokenValidationParameters = new TokenValidationParameters
         {
           ValidateIssuer = true,
           ValidIssuer = issuer,
           ValidateAudience = true,
-          ValidAudience = awsOptions.Cognito.AppClientId,
+          ValidAudience = expectedClientId,
+          AudienceValidator = (audiences, token, _) =>
+          {
+            // Cognito ID tokens have "aud" = client_id.
+            // Cognito access tokens omit "aud" and use "client_id" instead.
+            if (audiences.Any(a => string.Equals(a, expectedClientId, StringComparison.Ordinal)))
+            {
+              return true;
+            }
+
+            if (token is JsonWebToken jwt
+              && jwt.TryGetPayloadValue<string>("client_id", out var clientId))
+            {
+              return string.Equals(clientId, expectedClientId, StringComparison.Ordinal);
+            }
+
+            return false;
+          },
           ValidateLifetime = true,
           ValidateIssuerSigningKey = true,
           NameClaimType = "sub",

--- a/src/Aarogya.Api/Controllers/AuthController.cs
+++ b/src/Aarogya.Api/Controllers/AuthController.cs
@@ -373,9 +373,10 @@ public sealed class AuthController : ControllerBase
   [ProducesResponseType(typeof(PkceErrorResponse), StatusCodes.Status400BadRequest)]
   [ProducesResponseType(StatusCodes.Status401Unauthorized)]
   [ProducesResponseType(StatusCodes.Status403Forbidden)]
-  public IActionResult AssignRole([FromBody] RoleAssignmentCommand request)
+  public async Task<IActionResult> AssignRoleAsync(
+    [FromBody] RoleAssignmentCommand request,
+    CancellationToken cancellationToken)
   {
-
     var actorSub = User.FindFirstValue("sub");
     if (string.IsNullOrWhiteSpace(actorSub))
     {
@@ -388,12 +389,14 @@ public sealed class AuthController : ControllerBase
       .Distinct(StringComparer.OrdinalIgnoreCase)
       .ToArray();
 
-    if (!_roleAssignmentService.TryAssignRole(
+    var (success, message) = await _roleAssignmentService.TryAssignRoleAsync(
       actorSub,
       actorRoles,
       request.TargetUserSub,
       request.Role,
-      out var message))
+      cancellationToken);
+
+    if (!success)
     {
       return BadRequest(new PkceErrorResponse(message));
     }

--- a/src/Aarogya.Api/Program.cs
+++ b/src/Aarogya.Api/Program.cs
@@ -192,7 +192,7 @@ builder.Services.AddSingleton<IPkceAuthorizationService, InMemoryPkceAuthorizati
 builder.Services.AddSingleton<ICognitoSocialTokenClient, CognitoOAuthTokenClient>();
 builder.Services.AddSingleton<ISocialAuthService, CognitoSocialAuthService>();
 builder.Services.AddSingleton<ICognitoTokenManagementService, CognitoTokenManagementService>();
-builder.Services.AddSingleton<IRoleAssignmentService, InMemoryRoleAssignmentService>();
+builder.Services.AddScoped<IRoleAssignmentService, DatabaseRoleAssignmentService>();
 builder.Services.AddScoped<IUserAutoProvisioningService, UserAutoProvisioningService>();
 builder.Services.AddScoped<IAuditLoggingService, AuditLoggingService>();
 builder.Services.AddHostedService<DataEncryptionKeyRotationHostedService>();

--- a/tests/Aarogya.Api.Tests/AuthControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/AuthControllerTests.cs
@@ -92,14 +92,14 @@ public sealed class AuthControllerTests
 
   private sealed class NoopRoleAssignmentService : IRoleAssignmentService
   {
-    public bool TryAssignRole(string actorSub, IReadOnlyCollection<string> actorRoles, string targetSub, string targetRole, out string message)
-    {
-      message = "ok";
-      return true;
-    }
+    public Task<(bool Success, string Message)> TryAssignRoleAsync(
+      string actorSub, IReadOnlyCollection<string> actorRoles, string targetSub, string targetRole,
+      CancellationToken cancellationToken = default)
+      => Task.FromResult((true, "ok"));
 
-    public IReadOnlyCollection<string> GetAssignedRoles(string userSub)
-      => [];
+    public Task<IReadOnlyCollection<string>> GetAssignedRolesAsync(
+      string userSub, CancellationToken cancellationToken = default)
+      => Task.FromResult<IReadOnlyCollection<string>>([]);
   }
 
   private sealed class NoopSocialAuthService : ISocialAuthService

--- a/tests/Aarogya.Api.Tests/Authorization/AarogyaRoleClaimsTransformationTests.cs
+++ b/tests/Aarogya.Api.Tests/Authorization/AarogyaRoleClaimsTransformationTests.cs
@@ -17,8 +17,8 @@ public sealed class AarogyaRoleClaimsTransformationTests
   public AarogyaRoleClaimsTransformationTests()
   {
     _roleAssignmentServiceMock
-      .Setup(s => s.GetAssignedRoles(It.IsAny<string>()))
-      .Returns(Array.Empty<string>());
+      .Setup(s => s.GetAssignedRolesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(Array.Empty<string>());
 
     _transformation = new AarogyaRoleClaimsTransformation(_roleAssignmentServiceMock.Object);
   }
@@ -80,8 +80,8 @@ public sealed class AarogyaRoleClaimsTransformationTests
     var principal = new ClaimsPrincipal(identity);
 
     _roleAssignmentServiceMock
-      .Setup(s => s.GetAssignedRoles("user-1"))
-      .Returns(DoctorRole);
+      .Setup(s => s.GetAssignedRolesAsync("user-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(DoctorRole);
 
     var result = await _transformation.TransformAsync(principal);
 
@@ -122,8 +122,8 @@ public sealed class AarogyaRoleClaimsTransformationTests
     var principal = new ClaimsPrincipal(identity);
 
     _roleAssignmentServiceMock
-      .Setup(s => s.GetAssignedRoles("user-1"))
-      .Returns(PatientRole);
+      .Setup(s => s.GetAssignedRolesAsync("user-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(PatientRole);
 
     var result = await _transformation.TransformAsync(principal);
 

--- a/tests/Aarogya.Api.Tests/Authorization/RoleAssignmentServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/Authorization/RoleAssignmentServiceTests.cs
@@ -1,118 +1,149 @@
 using Aarogya.Api.Authorization;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Aarogya.Api.Tests.Authorization;
 
 public sealed class RoleAssignmentServiceTests
 {
-  private readonly InMemoryRoleAssignmentService _service = new();
+  private readonly Mock<IUserRepository> _userRepositoryMock = new();
+  private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+  private readonly DatabaseRoleAssignmentService _service;
+
+  public RoleAssignmentServiceTests()
+  {
+    _service = new DatabaseRoleAssignmentService(
+      _userRepositoryMock.Object,
+      _unitOfWorkMock.Object);
+  }
 
   [Fact]
-  public void TryAssignRole_ShouldReject_WhenActorIsNotAdmin()
+  public async Task TryAssignRoleAsync_ShouldReject_WhenActorIsNotAdminAsync()
   {
-    var success = _service.TryAssignRole(
+    var (success, message) = await _service.TryAssignRoleAsync(
       actorSub: "actor-1",
       actorRoles: ["Patient"],
       targetSub: "target-1",
-      targetRole: "Doctor",
-      out var message);
+      targetRole: "Doctor");
 
     success.Should().BeFalse();
     message.Should().Be("Only admins can assign roles.");
   }
 
   [Fact]
-  public void TryAssignRole_ShouldReject_WhenTargetRoleIsUnknown()
+  public async Task TryAssignRoleAsync_ShouldReject_WhenTargetRoleIsUnknownAsync()
   {
-    var success = _service.TryAssignRole(
+    var (success, message) = await _service.TryAssignRoleAsync(
       actorSub: "actor-1",
       actorRoles: ["Admin"],
       targetSub: "target-1",
-      targetRole: "SuperUser",
-      out var message);
+      targetRole: "SuperUser");
 
     success.Should().BeFalse();
     message.Should().Be("Unknown role.");
   }
 
   [Fact]
-  public void TryAssignRole_ShouldReject_WhenSelfEscalation()
+  public async Task TryAssignRoleAsync_ShouldReject_WhenSelfEscalationAsync()
   {
-    var success = _service.TryAssignRole(
+    var (success, message) = await _service.TryAssignRoleAsync(
       actorSub: "actor-1",
       actorRoles: ["Admin"],
       targetSub: "actor-1",
-      targetRole: "Doctor",
-      out var message);
+      targetRole: "Doctor");
 
     success.Should().BeFalse();
     message.Should().Be("Cannot escalate your own role.");
   }
 
   [Fact]
-  public void TryAssignRole_ShouldSucceed_WhenAdminAssignsValidRole()
+  public async Task TryAssignRoleAsync_ShouldReject_WhenUserNotFoundAsync()
   {
-    var success = _service.TryAssignRole(
+    _userRepositoryMock
+      .Setup(r => r.GetByExternalAuthIdAsync("target-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync((User?)null);
+
+    var (success, message) = await _service.TryAssignRoleAsync(
       actorSub: "admin-1",
       actorRoles: ["Admin"],
       targetSub: "target-1",
-      targetRole: "Doctor",
-      out var message);
+      targetRole: "Doctor");
+
+    success.Should().BeFalse();
+    message.Should().Contain("not found");
+  }
+
+  [Fact]
+  public async Task TryAssignRoleAsync_ShouldSucceed_WhenAdminAssignsValidRoleAsync()
+  {
+    var user = new User { ExternalAuthId = "target-1", Role = UserRole.Patient };
+    _userRepositoryMock
+      .Setup(r => r.GetByExternalAuthIdAsync("target-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
+
+    var (success, message) = await _service.TryAssignRoleAsync(
+      actorSub: "admin-1",
+      actorRoles: ["Admin"],
+      targetSub: "target-1",
+      targetRole: "Doctor");
 
     success.Should().BeTrue();
     message.Should().Contain("Doctor");
     message.Should().Contain("target-1");
+    user.Role.Should().Be(UserRole.Doctor);
+    _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
   }
 
   [Fact]
-  public void TryAssignRole_ShouldSucceed_WhenAdminReassignsSelfExistingRole()
+  public async Task TryAssignRoleAsync_ShouldSucceed_WhenAdminReassignsSelfExistingRoleAsync()
   {
-    var success = _service.TryAssignRole(
+    var user = new User { ExternalAuthId = "admin-1", Role = UserRole.Admin };
+    _userRepositoryMock
+      .Setup(r => r.GetByExternalAuthIdAsync("admin-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
+
+    var (success, message) = await _service.TryAssignRoleAsync(
       actorSub: "admin-1",
       actorRoles: ["Admin"],
       targetSub: "admin-1",
-      targetRole: "Admin",
-      out var message);
+      targetRole: "Admin");
 
     success.Should().BeTrue();
     message.Should().Contain("Admin");
   }
 
   [Fact]
-  public void GetAssignedRoles_ShouldReturnEmpty_ForUnknownUser()
+  public async Task GetAssignedRolesAsync_ShouldReturnEmpty_ForUnknownUserAsync()
   {
-    var roles = _service.GetAssignedRoles("nonexistent-user");
+    _userRepositoryMock
+      .Setup(r => r.GetByExternalAuthIdAsync("nonexistent-user", It.IsAny<CancellationToken>()))
+      .ReturnsAsync((User?)null);
+
+    var roles = await _service.GetAssignedRolesAsync("nonexistent-user");
     roles.Should().BeEmpty();
   }
 
   [Fact]
-  public void GetAssignedRoles_ShouldReturnEmpty_ForEmptyUserSub()
+  public async Task GetAssignedRolesAsync_ShouldReturnEmpty_ForEmptyUserSubAsync()
   {
-    var roles = _service.GetAssignedRoles("");
+    var roles = await _service.GetAssignedRolesAsync("");
     roles.Should().BeEmpty();
   }
 
   [Fact]
-  public void GetAssignedRoles_ShouldReturnAssignedRoles_AfterSuccessfulAssignment()
+  public async Task GetAssignedRolesAsync_ShouldReturnUserRole_WhenUserExistsAsync()
   {
-    _service.TryAssignRole(
-      actorSub: "admin-1",
-      actorRoles: ["Admin"],
-      targetSub: "target-1",
-      targetRole: "Doctor",
-      out _);
+    var user = new User { ExternalAuthId = "target-1", Role = UserRole.Doctor };
+    _userRepositoryMock
+      .Setup(r => r.GetByExternalAuthIdAsync("target-1", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
 
-    _service.TryAssignRole(
-      actorSub: "admin-1",
-      actorRoles: ["Admin"],
-      targetSub: "target-1",
-      targetRole: "Patient",
-      out _);
-
-    var roles = _service.GetAssignedRoles("target-1");
-    roles.Should().HaveCount(2);
+    var roles = await _service.GetAssignedRolesAsync("target-1");
+    roles.Should().HaveCount(1);
     roles.Should().Contain("Doctor");
-    roles.Should().Contain("Patient");
   }
 }

--- a/tests/Aarogya.Api.Tests/AuthorizationRbacTests.cs
+++ b/tests/Aarogya.Api.Tests/AuthorizationRbacTests.cs
@@ -1,21 +1,30 @@
 using System.Security.Claims;
 using Aarogya.Api.Authorization;
+using Aarogya.Domain.Entities;
+using Aarogya.Domain.Enums;
+using Aarogya.Domain.Repositories;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Aarogya.Api.Tests;
 
 public sealed class AuthorizationRbacTests
 {
+  private readonly Mock<IRoleAssignmentService> _roleAssignmentMock = new();
+
   [Fact]
   public async Task ClaimsTransformation_ShouldMapCognitoGroupsToRoleClaimsAsync()
   {
-    var roleAssignmentService = new InMemoryRoleAssignmentService();
+    _roleAssignmentMock
+      .Setup(s => s.GetAssignedRolesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(Array.Empty<string>());
+
     var principal = BuildPrincipal(
       new Claim("sub", "user-1"),
       new Claim("cognito:groups", "Doctor"));
 
-    var transformer = new AarogyaRoleClaimsTransformation(roleAssignmentService);
+    var transformer = new AarogyaRoleClaimsTransformation(_roleAssignmentMock.Object);
     var transformed = await transformer.TransformAsync(principal);
 
     transformed.Claims.Should().Contain(claim => claim.Type == ClaimTypes.Role && claim.Value == AarogyaRoles.Doctor);
@@ -24,51 +33,64 @@ public sealed class AuthorizationRbacTests
   [Fact]
   public async Task ClaimsTransformation_ShouldExpandAdminHierarchyAsync()
   {
-    var roleAssignmentService = new InMemoryRoleAssignmentService();
+    _roleAssignmentMock
+      .Setup(s => s.GetAssignedRolesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(Array.Empty<string>());
+
     var principal = BuildPrincipal(
       new Claim("sub", "admin-1"),
       new Claim("cognito:groups", "Admin"));
 
-    var transformer = new AarogyaRoleClaimsTransformation(roleAssignmentService);
+    var transformer = new AarogyaRoleClaimsTransformation(_roleAssignmentMock.Object);
     var transformed = await transformer.TransformAsync(principal);
 
     transformed.Claims.Should().Contain(claim => claim.Type == ClaimTypes.Role && claim.Value == AarogyaRoles.Admin);
     transformed.Claims.Should().Contain(claim => claim.Type == ClaimTypes.Role && claim.Value == AarogyaRoles.Patient);
     transformed.Claims.Should().Contain(claim => claim.Type == ClaimTypes.Role && claim.Value == AarogyaRoles.Doctor);
-    transformed.Claims.Should().Contain(claim => claim.Type == ClaimTypes.Role && claim.Value == AarogyaRoles.LabTechnician);
+    transformed.Claims.Should()
+      .Contain(claim => claim.Type == ClaimTypes.Role && claim.Value == AarogyaRoles.LabTechnician);
   }
 
   [Fact]
-  public void RoleAssignment_ShouldRejectSelfEscalation()
+  public async Task RoleAssignment_ShouldRejectSelfEscalationAsync()
   {
-    var service = new InMemoryRoleAssignmentService();
+    var userRepoMock = new Mock<IUserRepository>();
+    var unitOfWorkMock = new Mock<IUnitOfWork>();
+    var service = new DatabaseRoleAssignmentService(userRepoMock.Object, unitOfWorkMock.Object);
 
-    var success = service.TryAssignRole(
+    var (success, message) = await service.TryAssignRoleAsync(
       actorSub: "user-123",
       actorRoles: [AarogyaRoles.Admin],
       targetSub: "user-123",
-      targetRole: AarogyaRoles.Doctor,
-      out var message);
+      targetRole: AarogyaRoles.Doctor);
 
     success.Should().BeFalse();
     message.Should().Contain("Cannot escalate");
   }
 
   [Fact]
-  public void RoleAssignment_ShouldAllowAdminAssigningOtherUserRole()
+  public async Task RoleAssignment_ShouldAllowAdminAssigningOtherUserRoleAsync()
   {
-    var service = new InMemoryRoleAssignmentService();
+    var userRepoMock = new Mock<IUserRepository>();
+    var unitOfWorkMock = new Mock<IUnitOfWork>();
+    var user = new User { ExternalAuthId = "user-456", Role = UserRole.Patient };
+    userRepoMock
+      .Setup(r => r.GetByExternalAuthIdAsync("user-456", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(user);
+    var service = new DatabaseRoleAssignmentService(userRepoMock.Object, unitOfWorkMock.Object);
 
-    var success = service.TryAssignRole(
+    var (success, message) = await service.TryAssignRoleAsync(
       actorSub: "admin-1",
       actorRoles: [AarogyaRoles.Admin],
       targetSub: "user-456",
-      targetRole: AarogyaRoles.Doctor,
-      out var message);
+      targetRole: AarogyaRoles.Doctor);
 
     success.Should().BeTrue();
     message.Should().Contain("assigned");
-    service.GetAssignedRoles("user-456").Should().Contain(AarogyaRoles.Doctor);
+    user.Role.Should().Be(UserRole.Doctor);
+
+    var roles = await service.GetAssignedRolesAsync("user-456");
+    roles.Should().Contain(AarogyaRoles.Doctor);
   }
 
   private static ClaimsPrincipal BuildPrincipal(params Claim[] claims)


### PR DESCRIPTION
## Summary
- Replace `InMemoryRoleAssignmentService` with `DatabaseRoleAssignmentService` that reads user roles from PostgreSQL via `IUserRepository`, so auto-provisioned users (from PR #235) get their Patient role mapped to authorization claims
- Add custom `AudienceValidator` in Cognito JWT Bearer config to handle access tokens that use `client_id` instead of the standard `aud` claim
- Make `IRoleAssignmentService` fully async (`GetAssignedRolesAsync`, `TryAssignRoleAsync`)

## Test plan
- [x] All 603 tests pass (493 API + 69 Domain + 41 Infrastructure)
- [x] `dotnet format` clean
- [ ] End-to-end: Google social login → Cognito token → `GET /api/v1/users/me` returns 200 with auto-provisioned Patient profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)