### PR TITLE
feat(auth): support web and mobile redirect URIs for social auth

### DIFF
--- a/src/Aarogya.Api/Authentication/CognitoSocialAuthService.cs
+++ b/src/Aarogya.Api/Authentication/CognitoSocialAuthService.cs
@@ -26,9 +26,9 @@ internal sealed class CognitoSocialAuthService(
       return Task.FromResult(new SocialAuthorizeResult(false, $"Provider '{provider}' is not enabled."));
     }
 
-    if (!IsAllowedMobileRedirectUri(request.RedirectUri))
+    if (!IsAllowedRedirectUri(request.RedirectUri))
     {
-      return Task.FromResult(new SocialAuthorizeResult(false, "Redirect URI is not allowed for mobile OAuth flow."));
+      return Task.FromResult(new SocialAuthorizeResult(false, "Redirect URI is not in the allowed list."));
     }
 
     var state = string.IsNullOrWhiteSpace(request.State) ? JwtTokenHelpers.GenerateToken(16) : request.State.Trim();
@@ -76,9 +76,9 @@ internal sealed class CognitoSocialAuthService(
       return new SocialTokenResult(false, $"Provider '{provider}' is not enabled.");
     }
 
-    if (!IsAllowedMobileRedirectUri(request.RedirectUri))
+    if (!IsAllowedRedirectUri(request.RedirectUri))
     {
-      return new SocialTokenResult(false, "Redirect URI is not allowed for mobile OAuth flow.");
+      return new SocialTokenResult(false, "Redirect URI is not in the allowed list.");
     }
 
     if (string.IsNullOrWhiteSpace(request.AuthorizationCode))
@@ -109,14 +109,14 @@ internal sealed class CognitoSocialAuthService(
       false);
   }
 
-  private bool IsAllowedMobileRedirectUri(Uri redirectUri)
+  private bool IsAllowedRedirectUri(Uri redirectUri)
   {
     if (!redirectUri.IsAbsoluteUri)
     {
       return false;
     }
 
-    return _awsOptions.Cognito.SocialIdentityProviders.MobileRedirectUris
+    return _awsOptions.Cognito.SocialIdentityProviders.AllowedRedirectUris
       .Exists(uri => string.Equals(uri?.Trim(), redirectUri.ToString(), StringComparison.OrdinalIgnoreCase));
   }
 

--- a/src/Aarogya.Api/Configuration/AwsOptions.cs
+++ b/src/Aarogya.Api/Configuration/AwsOptions.cs
@@ -121,7 +121,7 @@ public sealed class CognitoSocialIdentityProviderOptions
   public SocialProviderOptions Facebook { get; set; } = new();
 
   [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Configuration binding requires mutable collection.")]
-  public List<string> MobileRedirectUris { get; set; } = [];
+  public List<string> AllowedRedirectUris { get; set; } = [];
 }
 
 public sealed class SocialProviderOptions

--- a/src/Aarogya.Api/Configuration/StartupExtensions.cs
+++ b/src/Aarogya.Api/Configuration/StartupExtensions.cs
@@ -198,10 +198,10 @@ public static class StartupExtensions
 
   private static void AddSocialProviderConfigurationViolations(IConfiguration configuration, List<string> violations)
   {
-    var redirectUris = configuration.GetSection("Aws:Cognito:SocialIdentityProviders:MobileRedirectUris").Get<string[]>() ?? [];
+    var redirectUris = configuration.GetSection("Aws:Cognito:SocialIdentityProviders:AllowedRedirectUris").Get<string[]>() ?? [];
     if (redirectUris.Length == 0 || Array.TrueForAll(redirectUris, IsMissingConfigurationValue))
     {
-      violations.Add("Missing Aws:Cognito:SocialIdentityProviders:MobileRedirectUris");
+      violations.Add("Missing Aws:Cognito:SocialIdentityProviders:AllowedRedirectUris");
     }
 
     foreach (var provider in new[] { "Google", "Apple", "Facebook" })

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -29,8 +29,10 @@
         "Facebook": {
           "Enabled": false
         },
-        "MobileRedirectUris": [
-          "aarogya://auth/callback"
+        "AllowedRedirectUris": [
+          "aarogya://auth/callback",
+          "http://localhost:3000/auth/callback",
+          "http://localhost:3000/api/auth/callback/cognito-pkce"
         ]
       },
       "MfaConfiguration": "OPTIONAL",

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -99,8 +99,9 @@
         "Facebook": {
           "Enabled": false
         },
-        "MobileRedirectUris": [
-          "aarogya://auth/callback"
+        "AllowedRedirectUris": [
+          "aarogya://auth/callback",
+          "SET_VIA_ENV_VAR"
         ]
       },
       "MfaConfiguration": "OPTIONAL",

--- a/tests/Aarogya.Api.Tests/CognitoSocialAuthServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/CognitoSocialAuthServiceTests.cs
@@ -169,7 +169,7 @@ public sealed class CognitoSocialAuthServiceTests
           Google = CreateEnabledProvider("google-client-id", "google-client-secret"),
           Apple = CreateEnabledProvider("apple-client-id", "apple-client-secret"),
           Facebook = CreateEnabledProvider("facebook-client-id", "facebook-client-secret"),
-          MobileRedirectUris = ["aarogya://auth/callback"]
+          AllowedRedirectUris = ["aarogya://auth/callback"]
         }
       }
     };

--- a/tests/Aarogya.Api.Tests/ConfigurationValidationTests.cs
+++ b/tests/Aarogya.Api.Tests/ConfigurationValidationTests.cs
@@ -196,7 +196,7 @@ public class ConfigurationValidationTests
       values[$"{providerKey}:ClientSecret"] = $"{providerId}-client-secret";
     }
 
-    values["Aws:Cognito:SocialIdentityProviders:MobileRedirectUris:0"] = "aarogya://auth/callback";
+    values["Aws:Cognito:SocialIdentityProviders:AllowedRedirectUris:0"] = "aarogya://auth/callback";
     values.TryAdd("Aws:Cognito:Domain", "aarogya-test");
     return values;
   }


### PR DESCRIPTION
## Summary
- Rename `MobileRedirectUris` → `AllowedRedirectUris` in config, options, validation, and social auth service to support both mobile and web frontends
- Add `http://localhost:3000/auth/callback` and `http://localhost:3000/api/auth/callback/cognito-pkce` (NextAuth) to dev config
- Production web URI configured via `SET_VIA_ENV_VAR` placeholder in `appsettings.json`
- Cognito app client updated with web callback URLs alongside existing mobile ones

## Test plan
- [x] All 603 tests pass (493 API + 69 Domain + 41 Infrastructure)
- [x] `dotnet format` clean
- [ ] Verify web frontend can complete Google social login via Cognito hosted UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)