### PR TITLE
feat(k8s): add Cognito config to backend deployment

### DIFF
--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -6,6 +6,12 @@ metadata:
 type: Opaque
 stringData:
   Jwt__Key: development-key-change-this-to-32-plus-chars
+  Aws__Cognito__UserPoolId: REPLACE_WITH_COGNITO_POOL_ID
+  Aws__Cognito__AppClientId: REPLACE_WITH_COGNITO_CLIENT_ID
+  Aws__Cognito__Issuer: REPLACE_WITH_COGNITO_ISSUER_URL
+  Aws__Cognito__Domain: REPLACE_WITH_COGNITO_DOMAIN_PREFIX
+  Google__ClientId: REPLACE_WITH_GOOGLE_CLIENT_ID
+  Google__ClientSecret: REPLACE_WITH_GOOGLE_CLIENT_SECRET
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -82,6 +88,42 @@ spec:
               value: Aarogya Dev
             - name: Aws__Cognito__UserPoolName
               value: aarogya-dev-users
+            - name: Aws__Cognito__UserPoolId
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Aws__Cognito__UserPoolId
+            - name: Aws__Cognito__AppClientId
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Aws__Cognito__AppClientId
+            - name: Aws__Cognito__Issuer
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Aws__Cognito__Issuer
+            - name: Aws__Cognito__Domain
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Aws__Cognito__Domain
+            - name: Aws__Cognito__SocialIdentityProviders__AllowedRedirectUris__0
+              value: "aarogya://auth/callback"
+            - name: Aws__Cognito__SocialIdentityProviders__AllowedRedirectUris__1
+              value: "http://localhost:3000/api/auth/callback/cognito-pkce"
+            - name: Aws__Cognito__SocialIdentityProviders__Google__Enabled
+              value: "true"
+            - name: Aws__Cognito__SocialIdentityProviders__Google__ClientId
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Google__ClientId
+            - name: Aws__Cognito__SocialIdentityProviders__Google__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Google__ClientSecret
             - name: Encryption__UseAwsKms
               value: "false"
             - name: Encryption__LocalDataKey


### PR DESCRIPTION
## Summary
- Add Cognito UserPoolId, AppClientId, Issuer, Domain to k8s secret (placeholders — real values applied at deploy time)
- Add Google IdP credentials to k8s secret
- Add AllowedRedirectUris and Google social provider env vars to deployment
- Cognito JWT validation uses explicit Issuer URL while S3/SQS continue using LocalStack

## Deploy instructions
Before applying, replace `REPLACE_WITH_*` placeholders in `api-secret` with real values:
```bash
kubectl create secret generic api-secret -n aarogya \
  --from-literal=Jwt__Key=... \
  --from-literal=Aws__Cognito__UserPoolId=ap-south-1_XXXXX \
  --from-literal=Aws__Cognito__AppClientId=XXXXX \
  --from-literal=Aws__Cognito__Issuer=https://cognito-idp.ap-south-1.amazonaws.com/ap-south-1_XXXXX \
  --from-literal=Aws__Cognito__Domain=aarogya-dev \
  --from-literal=Google__ClientId=XXXXX \
  --from-literal=Google__ClientSecret=XXXXX \
  --dry-run=client -o yaml | kubectl apply -f -
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)