### PR TITLE
feat(cd): inject secrets into k8s manifests via pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,26 @@ jobs:
         oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
         tags: tag:ci
 
+    - name: Inject secrets into manifests
+      env:
+        JWT_KEY: ${{ secrets.JWT_KEY }}
+        COGNITO_USER_POOL_ID: ${{ secrets.COGNITO_USER_POOL_ID }}
+        COGNITO_APP_CLIENT_ID: ${{ secrets.COGNITO_APP_CLIENT_ID }}
+        COGNITO_ISSUER_URL: ${{ secrets.COGNITO_ISSUER_URL }}
+        COGNITO_DOMAIN_PREFIX: ${{ secrets.COGNITO_DOMAIN_PREFIX }}
+        GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+        GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      run: |
+        sed -i \
+          -e "s|development-key-change-this-to-32-plus-chars|${JWT_KEY}|g" \
+          -e "s|REPLACE_WITH_COGNITO_POOL_ID|${COGNITO_USER_POOL_ID}|g" \
+          -e "s|REPLACE_WITH_COGNITO_CLIENT_ID|${COGNITO_APP_CLIENT_ID}|g" \
+          -e "s|REPLACE_WITH_COGNITO_ISSUER_URL|${COGNITO_ISSUER_URL}|g" \
+          -e "s|REPLACE_WITH_COGNITO_DOMAIN_PREFIX|${COGNITO_DOMAIN_PREFIX}|g" \
+          -e "s|REPLACE_WITH_GOOGLE_CLIENT_ID|${GOOGLE_CLIENT_ID}|g" \
+          -e "s|REPLACE_WITH_GOOGLE_CLIENT_SECRET|${GOOGLE_CLIENT_SECRET}|g" \
+          k8s/api.yaml
+
     - name: Deploy to k3s
       env:
         SSH_PRIVATE_KEY: ${{ secrets.DEV_SERVER_SSH_KEY }}


### PR DESCRIPTION
## Summary
- Adds a **secret substitution step** to the CD pipeline that replaces placeholder values in `k8s/api.yaml` with GitHub Actions secrets before deploying
- Covers: JWT key, Cognito User Pool ID/Client ID/Issuer/Domain, Google OAuth Client ID/Secret
- Secrets stay in GitHub Actions — never committed to the repo

## GitHub Actions Secrets Required

| Secret | Description |
|--------|-------------|
| `JWT_KEY` | HMAC-SHA256 signing key (32+ chars) |
| `COGNITO_USER_POOL_ID` | e.g. `ap-south-1_I827gkdF7` |
| `COGNITO_APP_CLIENT_ID` | Mobile public client ID |
| `COGNITO_ISSUER_URL` | e.g. `https://cognito-idp.ap-south-1.amazonaws.com/ap-south-1_I827gkdF7` |
| `COGNITO_DOMAIN_PREFIX` | e.g. `aarogya-dev` |
| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |

## Test plan
- [ ] Verify `api.yaml` placeholders match the `sed` patterns
- [ ] Add secrets to GitHub repo settings
- [ ] Trigger a deploy and verify the Secret resource has real values on the cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)