### PR TITLE
fix(auth): add role claim on first request for newly provisioned users

### DIFF
--- a/src/Aarogya.Api/Authentication/UserAutoProvisioningService.cs
+++ b/src/Aarogya.Api/Authentication/UserAutoProvisioningService.cs
@@ -73,5 +73,14 @@ internal sealed class UserAutoProvisioningService(
 
     logger.LogInformation("Auto-provisioned user {Sub} with role {Role}", sub, UserRole.Patient);
     await cacheService.SetAsync(cacheKey, true, CacheTtl, cancellationToken);
+
+    // IClaimsTransformation runs during UseAuthentication(), before this middleware,
+    // so the role claim was not added for newly created users. Add it now so
+    // UseAuthorization() sees the correct role on this first request.
+    if (principal.Identity is ClaimsIdentity identity
+      && !identity.HasClaim(ClaimTypes.Role, UserRole.Patient.ToString()))
+    {
+      identity.AddClaim(new Claim(ClaimTypes.Role, UserRole.Patient.ToString()));
+    }
   }
 }

--- a/tests/Aarogya.Api.Tests/UserAutoProvisioningServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/UserAutoProvisioningServiceTests.cs
@@ -4,6 +4,7 @@ using Aarogya.Api.Caching;
 using Aarogya.Domain.Entities;
 using Aarogya.Domain.Enums;
 using Aarogya.Domain.Repositories;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -111,6 +112,71 @@ public sealed class UserAutoProvisioningServiceTests
     await service.EnsureUserExistsAsync(principal);
 
     repo.Verify(r => r.GetByExternalAuthIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldAddRoleClaim_WhenNewUserCreatedAsync()
+  {
+    var (service, repo, uow, cache) = CreateService();
+    cache.Setup(c => c.GetAsync<bool>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(false);
+    repo.Setup(r => r.GetByExternalAuthIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync((User?)null);
+    repo.Setup(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+    var principal = CreatePrincipal("sub-new", "new@example.com", "Alice", "Smith");
+    await service.EnsureUserExistsAsync(principal);
+
+    var identity = principal.Identity as ClaimsIdentity;
+    identity.Should().NotBeNull();
+    identity!.HasClaim(ClaimTypes.Role, UserRole.Patient.ToString()).Should().BeTrue(
+      "newly provisioned users should get the Patient role claim added to their identity");
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldNotAddRoleClaim_WhenUserAlreadyExistsAsync()
+  {
+    var (service, repo, _, cache) = CreateService();
+    cache.Setup(c => c.GetAsync<bool>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(false);
+    repo.Setup(r => r.GetByExternalAuthIdAsync("sub-existing", It.IsAny<CancellationToken>()))
+      .ReturnsAsync(new User { ExternalAuthId = "sub-existing" });
+
+    var principal = CreatePrincipal("sub-existing", "existing@example.com");
+    await service.EnsureUserExistsAsync(principal);
+
+    var identity = principal.Identity as ClaimsIdentity;
+    identity.Should().NotBeNull();
+    identity!.HasClaim(ClaimTypes.Role, UserRole.Patient.ToString()).Should().BeFalse(
+      "existing users should not get role claims from auto-provisioning");
+  }
+
+  [Fact]
+  public async Task EnsureUserExistsAsync_ShouldNotDuplicateRoleClaim_WhenAlreadyPresentAsync()
+  {
+    var (service, repo, uow, cache) = CreateService();
+    cache.Setup(c => c.GetAsync<bool>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync(false);
+    repo.Setup(r => r.GetByExternalAuthIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+      .ReturnsAsync((User?)null);
+    repo.Setup(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+    uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+    var claims = new List<Claim>
+    {
+      new("sub", "sub-preexisting-role"),
+      new("email", "pre@example.com"),
+      new(ClaimTypes.Role, UserRole.Patient.ToString())
+    };
+    var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+
+    await service.EnsureUserExistsAsync(principal);
+
+    var identity = principal.Identity as ClaimsIdentity;
+    identity.Should().NotBeNull();
+    identity!.FindAll(ClaimTypes.Role).Should().HaveCount(1,
+      "the role claim should not be duplicated if already present");
   }
 
   private static (UserAutoProvisioningService Service, Mock<IUserRepository> Repo, Mock<IUnitOfWork> Uow, Mock<IEntityCacheService> Cache)


### PR DESCRIPTION
## Summary
- Fixes 403 Forbidden on the very first authenticated request for newly provisioned users
- `IClaimsTransformation` runs during `UseAuthentication()` before `UserAutoProvisioningMiddleware`, so new users had no role claims when `UseAuthorization()` ran
- After creating a user, the provisioning service now adds the `Patient` role claim directly to the `ClaimsPrincipal` so authorization succeeds on the same request

## Test plan
- [x] New test: `EnsureUserExistsAsync_ShouldAddRoleClaim_WhenNewUserCreatedAsync`
- [x] New test: `EnsureUserExistsAsync_ShouldNotAddRoleClaim_WhenUserAlreadyExistsAsync`
- [x] New test: `EnsureUserExistsAsync_ShouldNotDuplicateRoleClaim_WhenAlreadyPresentAsync`
- [x] All 496 API tests + 41 infrastructure tests pass
- [x] Manually verified via Cognito social login flow on K8s cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)