### PR TITLE
feat(infra): switch to real AWS services and Ollama LLM provider

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,21 +48,29 @@ jobs:
     - name: Inject secrets into manifests
       env:
         JWT_KEY: ${{ secrets.JWT_KEY }}
+        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         COGNITO_USER_POOL_ID: ${{ secrets.COGNITO_USER_POOL_ID }}
         COGNITO_APP_CLIENT_ID: ${{ secrets.COGNITO_APP_CLIENT_ID }}
         COGNITO_ISSUER_URL: ${{ secrets.COGNITO_ISSUER_URL }}
         COGNITO_DOMAIN_PREFIX: ${{ secrets.COGNITO_DOMAIN_PREFIX }}
         GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
         GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        ENCRYPTION_DATA_KEY: ${{ secrets.ENCRYPTION_DATA_KEY }}
+        ENCRYPTION_BLIND_INDEX_KEY: ${{ secrets.ENCRYPTION_BLIND_INDEX_KEY }}
       run: |
         sed -i \
           -e "s|development-key-change-this-to-32-plus-chars|${JWT_KEY}|g" \
+          -e "s|REPLACE_WITH_AWS_ACCESS_KEY|${AWS_ACCESS_KEY}|g" \
+          -e "s|REPLACE_WITH_AWS_SECRET_KEY|${AWS_SECRET_KEY}|g" \
           -e "s|REPLACE_WITH_COGNITO_POOL_ID|${COGNITO_USER_POOL_ID}|g" \
           -e "s|REPLACE_WITH_COGNITO_CLIENT_ID|${COGNITO_APP_CLIENT_ID}|g" \
           -e "s|REPLACE_WITH_COGNITO_ISSUER_URL|${COGNITO_ISSUER_URL}|g" \
           -e "s|REPLACE_WITH_COGNITO_DOMAIN_PREFIX|${COGNITO_DOMAIN_PREFIX}|g" \
           -e "s|REPLACE_WITH_GOOGLE_CLIENT_ID|${GOOGLE_CLIENT_ID}|g" \
           -e "s|REPLACE_WITH_GOOGLE_CLIENT_SECRET|${GOOGLE_CLIENT_SECRET}|g" \
+          -e "s|REPLACE_WITH_ENCRYPTION_DATA_KEY|${ENCRYPTION_DATA_KEY}|g" \
+          -e "s|REPLACE_WITH_ENCRYPTION_BLIND_INDEX_KEY|${ENCRYPTION_BLIND_INDEX_KEY}|g" \
           k8s/api.yaml
 
     - name: Deploy to k3s

--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -6,12 +6,16 @@ metadata:
 type: Opaque
 stringData:
   Jwt__Key: development-key-change-this-to-32-plus-chars
+  Aws__AccessKey: REPLACE_WITH_AWS_ACCESS_KEY
+  Aws__SecretKey: REPLACE_WITH_AWS_SECRET_KEY
   Aws__Cognito__UserPoolId: REPLACE_WITH_COGNITO_POOL_ID
   Aws__Cognito__AppClientId: REPLACE_WITH_COGNITO_CLIENT_ID
   Aws__Cognito__Issuer: REPLACE_WITH_COGNITO_ISSUER_URL
   Aws__Cognito__Domain: REPLACE_WITH_COGNITO_DOMAIN_PREFIX
   Google__ClientId: REPLACE_WITH_GOOGLE_CLIENT_ID
   Google__ClientSecret: REPLACE_WITH_GOOGLE_CLIENT_SECRET
+  Encryption__LocalDataKey: REPLACE_WITH_ENCRYPTION_DATA_KEY
+  Encryption__BlindIndexKey: REPLACE_WITH_ENCRYPTION_BLIND_INDEX_KEY
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -30,10 +34,6 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-secret
-      initContainers:
-        - name: wait-for-localstack
-          image: busybox:1.36
-          command: ['sh', '-c', 'until wget -qO- http://localstack:4566/_localstack/health; do sleep 2; done']
       containers:
         - name: aarogya-api
           image: ghcr.io/kinveetech/aarogyabackend:latest
@@ -64,28 +64,37 @@ spec:
               value: "true"
             - name: Database__AutoMigrateOnStartup
               value: "true"
+            # --- AWS Configuration (real services, no LocalStack) ---
             - name: Aws__Region
               value: ap-south-1
-            - name: Aws__ServiceUrl
-              value: http://localstack:4566
             - name: Aws__UseLocalStack
-              value: "true"
+              value: "false"
             - name: Aws__AccessKey
-              value: test
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Aws__AccessKey
             - name: Aws__SecretKey
-              value: test
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Aws__SecretKey
+            # --- S3 ---
             - name: Aws__S3__BucketName
               value: aarogya-dev
+            # --- SQS ---
             - name: Aws__Sqs__QueueName
               value: aarogya-dev-queue
             - name: Aws__Sqs__ConfigureS3NotificationsOnStartup
               value: "true"
             - name: Aws__Sqs__EnableUploadEventConsumer
               value: "true"
+            # --- SES ---
             - name: Aws__Ses__SenderEmail
               value: noreply@aarogya.dev
             - name: Aws__Ses__SenderName
               value: Aarogya Dev
+            # --- Cognito ---
             - name: Aws__Cognito__UserPoolName
               value: aarogya-dev-users
             - name: Aws__Cognito__UserPoolId
@@ -124,12 +133,24 @@ spec:
                 secretKeyRef:
                   name: api-secret
                   key: Google__ClientSecret
+            # --- Encryption (local keys for dev, KMS disabled) ---
             - name: Encryption__UseAwsKms
               value: "false"
             - name: Encryption__LocalDataKey
-              value: aarogya-local-dev-encryption-key
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Encryption__LocalDataKey
             - name: Encryption__BlindIndexKey
-              value: aarogya-local-dev-blind-index-key
+              valueFrom:
+                secretKeyRef:
+                  name: api-secret
+                  key: Encryption__BlindIndexKey
+            # --- PDF Extraction (Ollama, not Bedrock) ---
+            - name: PdfExtraction__LlmProvider
+              value: "ollama"
+            - name: PdfExtraction__OllamaEndpoint
+              value: "http://ollama:11434"
           livenessProbe:
             httpGet:
               path: /health

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -225,7 +225,7 @@
     "BatchSize": 10,
     "MinTextLengthPerPage": 50,
     "MaxRetryAttempts": 3,
-    "LlmProvider": "bedrock",
+    "LlmProvider": "ollama",
     "OllamaEndpoint": "http://localhost:11434",
     "OllamaModelId": "qwen2.5:14b-instruct",
     "BedrockModelId": "anthropic.claude-sonnet-4-20250514",


### PR DESCRIPTION
## Summary
- Disables Bedrock, switches default LLM provider to **Ollama** (cost savings)
- Removes LocalStack dependency from K8s deployment (no more init container)
- All AWS services (S3, SQS, SES, Cognito, Textract) now point to real AWS in ap-south-1
- Encryption keys and AWS credentials moved into K8s secrets with CD pipeline injection

## AWS Resources Created
- **S3**: `aarogya-dev` and `aarogya-dev-quarantine` buckets (public access blocked)
- **SQS**: `aarogya-dev-queue` with S3 notification policy
- **SES**: `noreply@aarogya.dev` identity (sandbox mode)
- **IAM**: `aarogya-dev-api` user with least-privilege policy (S3, SQS, SES, Cognito read, Textract)
- **Cognito**: existing `aarogya-dev-users` pool (unchanged)

## GitHub Secrets Added
- `AWS_ACCESS_KEY`, `AWS_SECRET_KEY` (for `aarogya-dev-api` IAM user)
- `ENCRYPTION_DATA_KEY`, `ENCRYPTION_BLIND_INDEX_KEY` (AES-256 random keys)

## Files Changed
- `appsettings.json` — LlmProvider: bedrock → ollama
- `k8s/api.yaml` — Remove LocalStack, add real AWS env vars, secrets for credentials + encryption
- `.github/workflows/cd.yml` — Inject 4 new secrets into manifest

## Test plan
- [x] All 496 API + 41 infrastructure tests pass
- [x] Format check clean
- [ ] After merge: verify CD pipeline deploys successfully
- [ ] Verify S3 upload, SQS processing, Cognito auth work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)