### PR TITLE
fix(aws): use correct SQS policy condition key for S3 notifications

### DIFF
--- a/src/Aarogya.Api/Features/V1/Reports/S3UploadNotificationConfiguratorHostedService.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/S3UploadNotificationConfiguratorHostedService.cs
@@ -110,11 +110,11 @@ internal sealed class S3UploadNotificationConfiguratorHostedService(
           Principal = new { Service = "s3.amazonaws.com" },
           Action = "sqs:SendMessage",
           Resource = queueArn,
-          Condition = new
+          Condition = new Dictionary<string, object>(StringComparer.Ordinal)
           {
-            ArnEquals = new
+            ["ArnLike"] = new Dictionary<string, string>(StringComparer.Ordinal)
             {
-              SourceArn = bucketArn
+              ["aws:SourceArn"] = bucketArn
             }
           }
         }


### PR DESCRIPTION
## Summary
- Fixed SQS queue policy condition in `S3UploadNotificationConfiguratorHostedService` to use `ArnLike` with `aws:SourceArn` instead of `ArnEquals` with `SourceArn`
- The incorrect condition key caused S3 `PutBucketNotification` to fail with "Unable to validate destination configurations", crashing the backend pod on startup

## Test plan
- [ ] CI passes (build, tests, lint)
- [ ] Deploy to dev server and verify pod starts without crash
- [ ] Verify S3→SQS notification is configured correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)