### PR TITLE
feat(k8s): add TLS ingress via Traefik and cert-manager

### DIFF
--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -121,6 +121,8 @@ spec:
               value: "aarogya://auth/callback"
             - name: Aws__Cognito__SocialIdentityProviders__AllowedRedirectUris__1
               value: "http://localhost:3000/api/auth/callback/cognito-pkce"
+            - name: Aws__Cognito__SocialIdentityProviders__AllowedRedirectUris__2
+              value: "https://dev.kinvee.in/api/auth/callback/cognito-pkce"
             - name: Aws__Cognito__SocialIdentityProviders__Google__Enabled
               value: "true"
             - name: Aws__Cognito__SocialIdentityProviders__Google__ClientId
@@ -170,11 +172,10 @@ metadata:
   name: aarogya-api
   namespace: aarogya
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: aarogya-api
   ports:
     - name: http
       port: 80
       targetPort: 8080
-      nodePort: 30080

--- a/k8s/cert-issuer.yaml
+++ b/k8s/cert-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: skrx7392@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            class: traefik

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aarogya-api-ingress
+  namespace: aarogya
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - api.dev.kinvee.in
+      secretName: api-tls
+  rules:
+    - host: api.dev.kinvee.in
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: aarogya-api
+                port:
+                  number: 80

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - cert-issuer.yaml
   - postgres.yaml
   - redis.yaml
   - localstack.yaml
   - pgadmin.yaml
   - api.yaml
+  - ingress.yaml


### PR DESCRIPTION
## Summary
- Add Let's Encrypt ClusterIssuer for automatic TLS certificate provisioning
- Add Traefik Ingress for `api.dev.kinvee.in` with TLS termination
- Switch API Service from NodePort (30080) to ClusterIP — external traffic goes through Traefik
- Add `https://dev.kinvee.in/api/auth/callback/cognito-pkce` to allowed redirect URIs

## Test plan
- [ ] CI passes
- [ ] After DNS propagates, cert-manager issues TLS certificate for api.dev.kinvee.in
- [ ] `https://api.dev.kinvee.in/health` responds with 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)