### PR TITLE
fix(k8s): switch cert-manager from HTTP-01 to DNS-01 challenge

### DIFF
--- a/k8s/cert-issuer.yaml
+++ b/k8s/cert-issuer.yaml
@@ -9,6 +9,11 @@ spec:
     privateKeySecretRef:
       name: letsencrypt-prod-key
     solvers:
-      - http01:
-          ingress:
-            class: traefik
+      - dns01:
+          route53:
+            region: ap-south-1
+            hostedZoneID: Z03680532RXMMGHR1HB0Y
+            accessKeyID: AKIAYTML4Z2XWYAKVWM5
+            secretAccessKeySecretRef:
+              name: route53-credentials
+              key: secret-access-key


### PR DESCRIPTION
## Summary
- Switch ClusterIssuer ACME solver from HTTP-01 to DNS-01 via Route 53
- Server is behind NAT without port 80/443 forwarding, making HTTP-01 impossible
- DNS-01 with Route 53 validates domain ownership regardless of NAT configuration

## Test plan
- [x] ClusterIssuer applied to cluster
- [x] TLS certificates issued for `dev.kinvee.in` and `api.dev.kinvee.in`
- [x] HTTPS verified working for both frontend and backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)