### PR TITLE
feat(auth): add Cognito pre-signup Lambda to auto-verify social auth emails

### DIFF
--- a/lambdas/pre-signup/index.mjs
+++ b/lambdas/pre-signup/index.mjs
@@ -1,0 +1,7 @@
+export const handler = async (event) => {
+  if (event.triggerSource === 'PreSignUp_ExternalProvider') {
+    event.response.autoConfirmUser = true;
+    event.response.autoVerifyEmail = true;
+  }
+  return event;
+};


### PR DESCRIPTION
## Summary
- Adds a Cognito Pre-SignUp Lambda trigger (`lambdas/pre-signup/index.mjs`) that auto-confirms and auto-verifies email for social auth (Google/Apple/Facebook) sign-ups
- When `triggerSource` is `PreSignUp_ExternalProvider`, sets `autoConfirmUser = true` and `autoVerifyEmail = true`
- Standard AWS-recommended pattern to fix `email_verified = false` for federated users

## Deployment steps
1. Zip and deploy the Lambda to AWS (`nodejs22.x`)
2. Create IAM execution role with `AWSLambdaBasicExecutionRole`
3. Grant Cognito permission to invoke the Lambda
4. Attach to user pool `ap-south-1_I827gkdF7` as Pre-SignUp trigger
5. Fix existing users via `admin-update-user-attributes`

## Test plan
- [ ] Deploy Lambda and attach to Cognito user pool
- [ ] Fix existing user's `email_verified` attribute
- [ ] Sign out and sign in with Google → verify `email_verified = true`
- [ ] New Google sign-up → `email_verified = true` from the start

🤖 Generated with [Claude Code](https://claude.com/claude-code)