### PR TITLE
feat(auth): add Apple and Facebook social auth providers

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -30,6 +30,12 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
       TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
       TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      TF_VAR_apple_client_id: ${{ secrets.APPLE_CLIENT_ID }}
+      TF_VAR_apple_team_id: ${{ secrets.APPLE_TEAM_ID }}
+      TF_VAR_apple_key_id: ${{ secrets.APPLE_KEY_ID }}
+      TF_VAR_apple_private_key: ${{ secrets.APPLE_PRIVATE_KEY }}
+      TF_VAR_facebook_app_id: ${{ secrets.FACEBOOK_APP_ID }}
+      TF_VAR_facebook_app_secret: ${{ secrets.FACEBOOK_APP_SECRET }}
 
     steps:
       - uses: actions/checkout@v4

--- a/infra/terraform/environments/dev.tfvars
+++ b/infra/terraform/environments/dev.tfvars
@@ -1,9 +1,15 @@
 environment = "dev"
 aws_region  = "ap-south-1"
 
-# Google OAuth — pass via TF_VAR_ environment variables to avoid storing here:
+# Social auth credentials — pass via TF_VAR_ environment variables to avoid storing here:
 #   export TF_VAR_google_client_id="..."
 #   export TF_VAR_google_client_secret="..."
+#   export TF_VAR_apple_client_id="..."
+#   export TF_VAR_apple_team_id="..."
+#   export TF_VAR_apple_key_id="..."
+#   export TF_VAR_apple_private_key="..."
+#   export TF_VAR_facebook_app_id="..."
+#   export TF_VAR_facebook_app_secret="..."
 
 cognito_callback_urls = [
   "aarogya://auth/callback",

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -92,6 +92,12 @@ module "cognito" {
   pre_signup_lambda_arn = module.lambda_pre_signup.function_arn
   google_client_id      = var.google_client_id
   google_client_secret  = var.google_client_secret
+  apple_client_id       = var.apple_client_id
+  apple_team_id         = var.apple_team_id
+  apple_key_id          = var.apple_key_id
+  apple_private_key     = var.apple_private_key
+  facebook_app_id       = var.facebook_app_id
+  facebook_app_secret   = var.facebook_app_secret
   callback_urls         = var.cognito_callback_urls
 }
 

--- a/infra/terraform/modules/cognito/main.tf
+++ b/infra/terraform/modules/cognito/main.tf
@@ -74,6 +74,51 @@ resource "aws_cognito_identity_provider" "google" {
   }
 }
 
+resource "aws_cognito_identity_provider" "apple" {
+  count = var.apple_client_id != "" ? 1 : 0
+
+  user_pool_id  = aws_cognito_user_pool.this.id
+  provider_name = "SignInWithApple"
+  provider_type = "SignInWithApple"
+
+  provider_details = {
+    client_id        = var.apple_client_id
+    team_id          = var.apple_team_id
+    key_id           = var.apple_key_id
+    private_key      = var.apple_private_key
+    authorize_scopes = "email name"
+  }
+
+  attribute_mapping = {
+    email       = "email"
+    given_name  = "firstName"
+    family_name = "lastName"
+    username    = "sub"
+  }
+}
+
+resource "aws_cognito_identity_provider" "facebook" {
+  count = var.facebook_app_id != "" ? 1 : 0
+
+  user_pool_id  = aws_cognito_user_pool.this.id
+  provider_name = "Facebook"
+  provider_type = "Facebook"
+
+  provider_details = {
+    client_id        = var.facebook_app_id
+    client_secret    = var.facebook_app_secret
+    authorize_scopes = "email,public_profile"
+    api_version      = "v21.0"
+  }
+
+  attribute_mapping = {
+    email       = "email"
+    given_name  = "first_name"
+    family_name = "last_name"
+    username    = "id"
+  }
+}
+
 resource "aws_cognito_user_pool_client" "this" {
   name         = "${var.project}-${var.environment}-client"
   user_pool_id = aws_cognito_user_pool.this.id
@@ -89,6 +134,8 @@ resource "aws_cognito_user_pool_client" "this" {
   supported_identity_providers = compact([
     "COGNITO",
     var.google_client_id != "" ? "Google" : "",
+    var.apple_client_id != "" ? "SignInWithApple" : "",
+    var.facebook_app_id != "" ? "Facebook" : "",
   ])
 
   callback_urls = var.callback_urls
@@ -98,5 +145,9 @@ resource "aws_cognito_user_pool_client" "this" {
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_scopes                 = ["openid", "email", "profile"]
 
-  depends_on = [aws_cognito_identity_provider.google]
+  depends_on = [
+    aws_cognito_identity_provider.google,
+    aws_cognito_identity_provider.apple,
+    aws_cognito_identity_provider.facebook,
+  ]
 }

--- a/infra/terraform/modules/cognito/variables.tf
+++ b/infra/terraform/modules/cognito/variables.tf
@@ -30,6 +30,42 @@ variable "google_client_secret" {
   sensitive   = true
 }
 
+variable "apple_client_id" {
+  description = "Apple Services ID (e.g. in.kinvee.aarogya.auth)"
+  type        = string
+  sensitive   = true
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign In key ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "apple_private_key" {
+  description = "Apple Sign In private key (.p8 contents)"
+  type        = string
+  sensitive   = true
+}
+
+variable "facebook_app_id" {
+  description = "Facebook App ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "facebook_app_secret" {
+  description = "Facebook App Secret"
+  type        = string
+  sensitive   = true
+}
+
 variable "callback_urls" {
   description = "Allowed OAuth callback URLs"
   type        = list(string)

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -29,6 +29,42 @@ variable "google_client_secret" {
   sensitive   = true
 }
 
+variable "apple_client_id" {
+  description = "Apple Services ID for Cognito social sign-in"
+  type        = string
+  sensitive   = true
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign In key ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "apple_private_key" {
+  description = "Apple Sign In private key (.p8 contents)"
+  type        = string
+  sensitive   = true
+}
+
+variable "facebook_app_id" {
+  description = "Facebook App ID for Cognito social sign-in"
+  type        = string
+  sensitive   = true
+}
+
+variable "facebook_app_secret" {
+  description = "Facebook App Secret for Cognito social sign-in"
+  type        = string
+  sensitive   = true
+}
+
 variable "cognito_callback_urls" {
   description = "Allowed callback URLs for Cognito app client"
   type        = list(string)

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -94,10 +94,13 @@
           "ClientSecret": "SET_VIA_ENV_VAR"
         },
         "Apple": {
-          "Enabled": false
+          "Enabled": true,
+          "ClientId": "SET_VIA_ENV_VAR"
         },
         "Facebook": {
-          "Enabled": false
+          "Enabled": true,
+          "ClientId": "SET_VIA_ENV_VAR",
+          "ClientSecret": "SET_VIA_ENV_VAR"
         },
         "AllowedRedirectUris": [
           "aarogya://auth/callback",


### PR DESCRIPTION
## Summary
- Add Apple (`SignInWithApple`) and Facebook identity providers to the Cognito user pool via Terraform
- Wire Apple credentials (Services ID, Team ID, Key ID, private key) and Facebook credentials (App ID, App Secret) through GitHub Actions secrets
- Enable both providers in `appsettings.json`

## Changes
- **Terraform Cognito module**: Add `aws_cognito_identity_provider.apple` and `.facebook` resources with provider-specific attribute mappings
- **Terraform root**: Pass Apple/Facebook variables through to cognito module
- **GitHub Actions**: Add `TF_VAR_apple_*` and `TF_VAR_facebook_*` env vars from secrets
- **appsettings.json**: Flip Apple/Facebook to `Enabled: true`

## No application code changes needed
The backend (`CognitoSocialAuthService`) and frontend (login page) already support all three providers — this change only provisions the infrastructure.

## Test plan
- [ ] Terraform plan shows 2 to add (Apple + Facebook IdPs), 2 to change (client + Google drift)
- [ ] Terraform apply succeeds in CI
- [ ] Verify Apple Sign In flow via Cognito hosted UI
- [ ] Verify Facebook Login flow via Cognito hosted UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)