### PR TITLE
fix(infra): add s3:GetBucketAcl to IAM policy for bucket existence check

### DIFF
--- a/infra/terraform/modules/iam/main.tf
+++ b/infra/terraform/modules/iam/main.tf
@@ -25,6 +25,7 @@ data "aws_iam_policy_document" "api" {
       "s3:PutObject",
       "s3:DeleteObject",
       "s3:ListBucket",
+      "s3:GetBucketAcl",
       "s3:GetBucketLocation",
       "s3:GetBucketNotification",
       "s3:PutBucketNotification",


### PR DESCRIPTION
## Summary
- Add missing `s3:GetBucketAcl` permission to the `aarogya-dev-api` IAM user policy in Terraform

## Root cause
The `S3UploadNotificationConfiguratorHostedService` calls `GetBucketAcl` at startup to verify S3 buckets exist. This worked with LocalStack (no IAM enforcement) but every deployment since PR #241 (switch to real AWS) crashes because `s3:GetBucketAcl` is not in the IAM policy:

```
Amazon.S3.AmazonS3Exception: User: arn:aws:iam::591388266159:user/aarogya-dev-api 
is not authorized to perform: s3:GetBucketAcl on resource: "arn:aws:s3:::aarogya-dev"
```

## Test plan
- [ ] After merge: `terraform plan` shows IAM policy update
- [ ] `terraform apply` updates the IAM policy
- [ ] Re-deploy API pod — startup succeeds without S3 permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)