### PR TITLE
fix: add cascade stop to CreateReportRequest validator rules

### DIFF
--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -144,11 +144,16 @@ internal sealed class CreateReportRequestValidator : AbstractValidator<CreateRep
   public CreateReportRequestValidator()
   {
     RuleFor(x => x.ReportType)
+      .Cascade(CascadeMode.Stop)
       .NotEmpty()
       .Must(value => AllowedReportTypes.Contains(value.Trim(), StringComparer.OrdinalIgnoreCase))
       .WithMessage("ReportType must be one of blood_test, urine_test, radiology, cardiology, other.");
 
-    RuleFor(x => x.ObjectKey).NotEmpty().MaximumLength(1024).Must(value => value.Trim().StartsWith("reports/", StringComparison.Ordinal));
+    RuleFor(x => x.ObjectKey)
+      .Cascade(CascadeMode.Stop)
+      .NotEmpty()
+      .MaximumLength(1024)
+      .Must(value => value.Trim().StartsWith("reports/", StringComparison.Ordinal));
 
     RuleFor(x => x.LabName).NotEmpty().MaximumLength(200);
     RuleFor(x => x.LabCode).MaximumLength(100).When(x => x.LabCode is not null);
@@ -169,6 +174,7 @@ internal sealed class CreateReportRequestValidator : AbstractValidator<CreateRep
       .When(x => x.CollectedAt.HasValue && x.ReportedAt.HasValue);
 
     RuleFor(x => x.Parameters)
+      .Cascade(CascadeMode.Stop)
       .NotNull()
       .Must(parameters => parameters.Count > 0)
       .WithMessage("At least one parameter is required.");

--- a/tests/Aarogya.Api.Tests/Validation/RequestValidatorsTests.cs
+++ b/tests/Aarogya.Api.Tests/Validation/RequestValidatorsTests.cs
@@ -281,6 +281,60 @@ public sealed class RequestValidatorsTests
     result.IsValid.Should().BeFalse();
   }
 
+  [Fact]
+  public void CreateReportRequestValidator_ShouldReject_NullParameters()
+  {
+    var validator = new CreateReportRequestValidator();
+    var request = new CreateReportRequest(
+      ReportType: "blood_test",
+      ObjectKey: "reports/test-file.pdf",
+      LabName: "Apollo Lab",
+      LabCode: null,
+      CollectedAt: null,
+      ReportedAt: null,
+      Notes: null,
+      PatientSub: null,
+      Parameters: null!);
+    var result = validator.Validate(request);
+    result.IsValid.Should().BeFalse();
+  }
+
+  [Fact]
+  public void CreateReportRequestValidator_ShouldReject_NullReportType()
+  {
+    var validator = new CreateReportRequestValidator();
+    var request = new CreateReportRequest(
+      ReportType: null!,
+      ObjectKey: "reports/test-file.pdf",
+      LabName: "Apollo Lab",
+      LabCode: null,
+      CollectedAt: null,
+      ReportedAt: null,
+      Notes: null,
+      PatientSub: null,
+      Parameters: [new CreateReportParameterRequest("HGB", "Hemoglobin", 14.5m, null, "g/dL", "12.0-16.0", null)]);
+    var result = validator.Validate(request);
+    result.IsValid.Should().BeFalse();
+  }
+
+  [Fact]
+  public void CreateReportRequestValidator_ShouldReject_NullObjectKey()
+  {
+    var validator = new CreateReportRequestValidator();
+    var request = new CreateReportRequest(
+      ReportType: "blood_test",
+      ObjectKey: null!,
+      LabName: "Apollo Lab",
+      LabCode: null,
+      CollectedAt: null,
+      ReportedAt: null,
+      Notes: null,
+      PatientSub: null,
+      Parameters: [new CreateReportParameterRequest("HGB", "Hemoglobin", 14.5m, null, "g/dL", "12.0-16.0", null)]);
+    var result = validator.Validate(request);
+    result.IsValid.Should().BeFalse();
+  }
+
   #endregion
 
   #region CreateReportParameterRequestValidator


### PR DESCRIPTION
## Summary
- Adds `CascadeMode.Stop` to `ReportType`, `ObjectKey`, and `Parameters` rule chains in `CreateReportRequestValidator`
- Prevents `NullReferenceException` when null values reach `.Must()` lambdas (FluentValidation's `.NotEmpty()`/`.NotNull()` don't short-circuit by default)
- Adds 3 null-safety unit tests covering all three affected fields

## Test plan
- [x] All 7 `CreateReportRequestValidator` tests pass locally
- [ ] CI passes (build, test, format)
- [ ] Verify report upload no longer returns 500 on malformed requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)