### PR TITLE
fix: handle LLM timeout errors and configure Ollama HttpClient timeout

### DIFF
--- a/src/Aarogya.Api/Features/V1/Reports/PdfExtractionOptions.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/PdfExtractionOptions.cs
@@ -39,6 +39,9 @@ public sealed class PdfExtractionOptions
 
   public string? BedrockRegion { get; set; }
 
+  [Range(2, 30)]
+  public int LlmRequestTimeoutMinutes { get; set; } = 10;
+
   [Range(100, 8000)]
   public int MaxTokens { get; set; } = 4096;
 

--- a/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
+++ b/src/Aarogya.Api/Features/V1/Reports/ReportPdfExtractionProcessor.cs
@@ -128,7 +128,11 @@ internal sealed class ReportPdfExtractionProcessor(
         reportId,
         structuredResult.OverallConfidence);
     }
-    catch (Exception ex) when (ex is not OperationCanceledException)
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      throw;
+    }
+    catch (Exception ex)
     {
       logger.LogError(
         ex,
@@ -137,9 +141,11 @@ internal sealed class ReportPdfExtractionProcessor(
         report.Extraction.AttemptCount);
 
       report.Status = ReportStatus.ExtractionFailed;
-      report.Extraction.ErrorMessage = ex.Message;
+      report.Extraction.ErrorMessage = ex.InnerException is TimeoutException
+        ? $"LLM request timed out after {extractionOptions.Value.LlmRequestTimeoutMinutes} minutes."
+        : ex.Message;
 
-      await unitOfWork.SaveChangesAsync(cancellationToken);
+      await unitOfWork.SaveChangesAsync(CancellationToken.None);
     }
   }
 

--- a/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
+++ b/src/Aarogya.Api/Features/V1/V1FeatureServiceCollectionExtensions.cs
@@ -82,7 +82,12 @@ internal static class V1FeatureServiceCollectionExtensions
       services.AddSingleton<IChatClient>(sp =>
       {
         var options = sp.GetRequiredService<IOptions<PdfExtractionOptions>>().Value;
-        return new OllamaApiClient(new Uri(options.OllamaEndpoint), options.OllamaModelId);
+        var httpClient = new HttpClient
+        {
+          BaseAddress = new Uri(options.OllamaEndpoint),
+          Timeout = TimeSpan.FromMinutes(options.LlmRequestTimeoutMinutes)
+        };
+        return new OllamaApiClient(httpClient, options.OllamaModelId);
       });
     }
 

--- a/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportPdfExtractionProcessorTests.cs
+++ b/tests/Aarogya.Api.Tests/Features/V1/Reports/ReportPdfExtractionProcessorTests.cs
@@ -288,6 +288,49 @@ public sealed class ReportPdfExtractionProcessorTests
     report.Extraction!.RawExtractedText.Should().NotBeNull();
   }
 
+  [Fact]
+  public async Task ProcessReportAsync_ShouldSetExtractionFailed_WhenLlmTimesOutAsync()
+  {
+    var report = CreateReport();
+    SetupReportLookup(report);
+    SetupS3Download("Hemoglobin: 14.5 g/dL with enough text to pass min threshold per page");
+    SetupPdfPigExtraction("Hemoglobin: 14.5 g/dL with enough text to pass min threshold per page", 1);
+
+    var timeoutException = new TaskCanceledException(
+      "The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.",
+      new TimeoutException("The operation was canceled."));
+
+    _llmExtractorMock
+      .Setup(x => x.ExtractParametersAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(timeoutException);
+
+    await _processor.ProcessReportAsync(report.Id);
+
+    report.Status.Should().Be(ReportStatus.ExtractionFailed);
+    report.Extraction!.ErrorMessage.Should().Contain("timed out");
+  }
+
+  [Fact]
+  public async Task ProcessReportAsync_ShouldRethrow_WhenCancellationIsRequestedAsync()
+  {
+    var report = CreateReport();
+    SetupReportLookup(report);
+    SetupS3Download("Hemoglobin: 14.5 g/dL with enough text to pass min threshold per page");
+    SetupPdfPigExtraction("Hemoglobin: 14.5 g/dL with enough text to pass min threshold per page", 1);
+
+    using var cts = new CancellationTokenSource();
+    await cts.CancelAsync();
+
+    _llmExtractorMock
+      .Setup(x => x.ExtractParametersAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+      .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+    var act = () => _processor.ProcessReportAsync(report.Id, cancellationToken: cts.Token);
+
+    await act.Should().ThrowAsync<OperationCanceledException>();
+    report.Status.Should().Be(ReportStatus.Extracting);
+  }
+
   private static Report CreateReport(
     ReportStatus status = ReportStatus.Clean,
     string? fileStorageKey = "reports/test.pdf")


### PR DESCRIPTION
## Summary
- Fix extraction processor leaving reports stuck in `extracting` status when Ollama/LLM requests time out
- `TaskCanceledException` (from `HttpClient.Timeout`) is a subclass of `OperationCanceledException`, so it was bypassing the catch filter entirely
- Add configurable `LlmRequestTimeoutMinutes` (default 10 min) to `PdfExtractionOptions`
- Pass a properly configured `HttpClient` to `OllamaApiClient` with the timeout

## Changes
- **`ReportPdfExtractionProcessor.cs`**: Fix catch block to distinguish app cancellation (`CancellationToken.IsCancellationRequested`) from HTTP timeouts. Friendly error message for timeouts. Use `CancellationToken.None` when persisting error state.
- **`PdfExtractionOptions.cs`**: Add `LlmRequestTimeoutMinutes` property (range 2–30, default 10)
- **`V1FeatureServiceCollectionExtensions.cs`**: Create `HttpClient` with `BaseAddress` and `Timeout` before passing to `OllamaApiClient`
- **`ReportPdfExtractionProcessorTests.cs`**: Add tests for timeout handling and cancellation propagation

## Test plan
- [x] Existing 12 processor tests still pass
- [x] New `ShouldSetExtractionFailed_WhenLlmTimesOut` test verifies timeout → `ExtractionFailed` with friendly message
- [x] New `ShouldRethrow_WhenCancellationIsRequested` test verifies app shutdown still propagates
- [x] Full suite: 763 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)