### PR TITLE
fix: remove global string validator poisoning route params

### DIFF
--- a/src/Aarogya.Api/Validation/RequestValidators.cs
+++ b/src/Aarogya.Api/Validation/RequestValidators.cs
@@ -302,14 +302,6 @@ internal sealed class UpdateEmergencyContactRequestValidator : AbstractValidator
   }
 }
 
-internal sealed class AadhaarNumberValidator : AbstractValidator<string>
-{
-  public AadhaarNumberValidator()
-  {
-    RuleFor(x => x).MustBeAadhaarNumber();
-  }
-}
-
 internal sealed class VerifyAadhaarRequestValidator : AbstractValidator<VerifyAadhaarRequest>
 {
   private static readonly DateOnly MinimumBirthDate = new(1900, 1, 1);


### PR DESCRIPTION
## Summary
- Removed `AadhaarNumberValidator : AbstractValidator<string>` which was auto-discovered by FluentValidation and applied to **every** string parameter in the app
- This caused `PUT /v1/consents/{purpose}` to fail with "Aadhaar must be a 12-digit number" when `purpose` was "analytics"
- Aadhaar validation is already correctly scoped in `VerifyAadhaarRequestValidator` via `MustBeAadhaarNumber()`

## Test plan
- [x] All 763 backend tests pass
- [ ] Verify `PUT /v1/consents/analytics` returns 200 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)