### PR TITLE
fix(k8s): mount postgres volume at /var/lib/postgresql for postgres 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
       - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U aarogya -d aarogya"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      # postgres:18+ layout — data lives in a version subdirectory under this mount.
+      # A pgdata volume created by postgres:16 (mounted at /var/lib/postgresql/data)
+      # is not migrated; recreate it with `docker compose down -v` (dev data is disposable).
       - pgdata:/var/lib/postgresql
       - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
     healthcheck:

--- a/k8s/postgres.yaml
+++ b/k8s/postgres.yaml
@@ -43,7 +43,7 @@ spec:
                 name: postgres-secret
           volumeMounts:
             - name: pgdata
-              mountPath: /var/lib/postgresql/data
+              mountPath: /var/lib/postgresql
             - name: postgres-init-sql
               mountPath: /docker-entrypoint-initdb.d
           readinessProbe:


### PR DESCRIPTION
## Summary
The postgres:18 rollout from #270 is stuck in CrashLoopBackOff on the dev cluster: the official postgres:18 image relocated its data directory (version-specific subdirectory under `/var/lib/postgresql`, see docker-library/postgres#1259) and its entrypoint refuses to start when a volume is mounted at the legacy `/var/lib/postgresql/data` path.

Fix: mount the volume at `/var/lib/postgresql` in both `k8s/postgres.yaml` and `docker-compose.yml`. Dev data is emptyDir/disposable, so no pg_upgrade path is needed — the fresh 18 cluster initializes into the new layout on rollout.

## Testing
- Root cause confirmed from the crashing pod's entrypoint log on the dev cluster (old postgres:16 pod still serving; API healthy throughout).
- CD will apply the manifest on merge; rollout verified after.