### PR TITLE
fix(reports): use gemma4:e4b for PDF extraction instead of qwen2.5:14b

### DIFF
--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -153,6 +153,8 @@ spec:
               value: "ollama"
             - name: PdfExtraction__OllamaEndpoint
               value: "http://ollama:11434"
+            - name: PdfExtraction__OllamaModelId
+              value: "gemma4:e4b"
           livenessProbe:
             httpGet:
               path: /health

--- a/src/Aarogya.Api/appsettings.Development.json
+++ b/src/Aarogya.Api/appsettings.Development.json
@@ -145,7 +145,7 @@
     "MaxRetryAttempts": 3,
     "LlmProvider": "ollama",
     "OllamaEndpoint": "http://10.0.10.113:11434",
-    "OllamaModelId": "qwen2.5:14b-instruct",
+    "OllamaModelId": "gemma4:e4b",
     "BedrockModelId": "anthropic.claude-sonnet-4-20250514",
     "MaxTokens": 4096,
     "MinConfidenceThreshold": 0.5,

--- a/src/Aarogya.Api/appsettings.json
+++ b/src/Aarogya.Api/appsettings.json
@@ -230,7 +230,7 @@
     "MaxRetryAttempts": 3,
     "LlmProvider": "ollama",
     "OllamaEndpoint": "http://localhost:11434",
-    "OllamaModelId": "qwen2.5:14b-instruct",
+    "OllamaModelId": "gemma4:e4b",
     "BedrockModelId": "anthropic.claude-sonnet-4-20250514",
     "MaxTokens": 4096,
     "MinConfidenceThreshold": 0.5,


### PR DESCRIPTION
## Problem

After the stack upgrade + dev DB reset, AI parameter extraction failed on **every** new report upload. Two causes:

1. The configured model `qwen2.5:14b-instruct` was missing from Ollama on the inference host (extraction got **404**).
2. Even once present, the 14B model does not fit the dev GPU (RTX 3080) — it runs ~80% on CPU, so a single extraction takes minutes and hits a **5-minute timeout → 500** (`TaskCanceledException`).

## Change

Switch `PdfExtraction.OllamaModelId` to **`gemma4:e4b`**, which is already present on the host and much smaller.

- `src/Aarogya.Api/appsettings.json` and `appsettings.Development.json` — model id
- `k8s/api.yaml` — pin `PdfExtraction__OllamaModelId` as an explicit env var so the deployment doesn't silently rely on the baked-in default

## Verification

Triggered a re-extraction on a live dev report after switching:

```
Successfully extracted 13 parameters from report ... with confidence 1.00
HTTP POST /api/v1/reports/{id}/extract responded 202 in 36437 ms
```

Full CBC panel extracted (13/13 parameters) in ~36s vs the prior 5-minute timeout. qwen2.5:14b has been removed from the host.

## Notes

The underlying robustness gap (no graceful timeout / retry UX when the LLM is slow or the model is absent) is tracked separately.