### PR TITLE
fix(consents): return 200 on consent upsert and expose aadhaarVerified in profile

### DIFF
--- a/src/Aarogya.Api/Caching/EntityCacheKeys.cs
+++ b/src/Aarogya.Api/Caching/EntityCacheKeys.cs
@@ -11,8 +11,10 @@ internal static class EntityCacheNamespaces
 
 internal static class EntityCacheKeys
 {
+  // v2: UserProfileResponse gained AadhaarVerified — entries cached under the old key
+  // deserialize with the default (false), so the schema change requires a new key
   public static string UserProfile(string userSub)
-    => $"cache:user-profile:{Hash(userSub)}";
+    => $"cache:user-profile:v2:{Hash(userSub)}";
 
   public static string AccessGrantListForPatient(string patientSub, string version)
     => $"cache:access-grants:patient:{version}:{Hash(patientSub)}";

--- a/src/Aarogya.Api/Features/V1/Consents/ConsentContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Consents/ConsentContracts.cs
@@ -10,7 +10,9 @@ namespace Aarogya.Api.Features.V1.Consents;
   Justification = "Used by public API action signature for model binding.")]
 public sealed record UpsertConsentRequest(
   [property: JsonRequired] bool IsGranted,
-  [property: MaxLength(80)] string Source = "api");
+  // Validation attributes on record types must target the constructor parameter, not the
+  // property — MVC's record validation throws InvalidOperationException otherwise
+  [MaxLength(80)] string Source = "api");
 
 [SuppressMessage(
   "Performance",

--- a/src/Aarogya.Api/Features/V1/Users/UserContracts.cs
+++ b/src/Aarogya.Api/Features/V1/Users/UserContracts.cs
@@ -18,7 +18,8 @@ public sealed record UserProfileResponse(
   DateOnly? DateOfBirth,
   string? Gender,
   string RegistrationStatus,
-  IReadOnlyList<string> Roles);
+  IReadOnlyList<string> Roles,
+  bool AadhaarVerified);
 
 [SuppressMessage(
   "Performance",

--- a/src/Aarogya.Api/Features/V1/Users/UserProfileService.cs
+++ b/src/Aarogya.Api/Features/V1/Users/UserProfileService.cs
@@ -161,7 +161,8 @@ internal sealed class UserProfileService(
       user.DateOfBirth,
       user.Gender,
       ToRegistrationStatusName(user.RegistrationStatus),
-      [ToRoleName(user.Role)]);
+      [ToRoleName(user.Role)],
+      user.AadhaarRefToken is not null);
   }
 
   private static string ToRegistrationStatusName(RegistrationStatus status)

--- a/tests/Aarogya.Api.Tests/CachedUserProfileServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/CachedUserProfileServiceTests.cs
@@ -29,7 +29,8 @@ public sealed class CachedUserProfileServiceTests
     new DateOnly(1990, 5, 15),
     null,
     "approved",
-    ["Patient"]);
+    ["Patient"],
+    false);
 
   [Fact]
   public async Task GetCurrentUserAsync_ShouldReturnCachedResponse_WhenCacheHitAsync()

--- a/tests/Aarogya.Api.Tests/RequestContractConventionTests.cs
+++ b/tests/Aarogya.Api.Tests/RequestContractConventionTests.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using Aarogya.Api.Features.V1.Consents;
+using AwesomeAssertions;
+using Xunit;
+
+namespace Aarogya.Api.Tests;
+
+/// <summary>
+/// ASP.NET Core MVC validates positional records through their constructor parameters and throws
+/// <see cref="InvalidOperationException"/> at request time when a validation attribute targets a
+/// record property instead (ThrowIfRecordTypeHasValidationOnProperties). A misplaced
+/// <c>[property: ...]</c> target therefore turns every request against that endpoint into a 500.
+/// </summary>
+public sealed class RequestContractConventionTests
+{
+  [Fact]
+  public void RequestContractRecords_ShouldNotCarryValidationAttributesOnProperties()
+  {
+    var apiAssembly = typeof(UpsertConsentRequest).Assembly;
+
+    var requestRecords = apiAssembly
+      .GetTypes()
+      .Where(t => t.IsClass
+        && !t.IsAbstract
+        && t.Name.EndsWith("Request", StringComparison.Ordinal)
+        && t.Namespace?.Contains(".Features.", StringComparison.Ordinal) == true)
+      .ToList();
+
+    requestRecords.Should().NotBeEmpty();
+
+    var offenders = new List<string>();
+    foreach (var type in requestRecords)
+    {
+      var constructorParameterNames = type
+        .GetConstructors()
+        .SelectMany(c => c.GetParameters())
+        .Select(p => p.Name)
+        .Where(n => n is not null)
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+      foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+      {
+        if (!constructorParameterNames.Contains(property.Name))
+        {
+          continue;
+        }
+
+        if (property.GetCustomAttributes<ValidationAttribute>(inherit: true).Any())
+        {
+          offenders.Add($"{type.Name}.{property.Name}");
+        }
+      }
+    }
+
+    offenders.Should().BeEmpty(
+      "validation attributes on positional record contracts must target the constructor parameter "
+      + "(e.g. [MaxLength(80)]), not the property (e.g. [property: MaxLength(80)]), "
+      + "or MVC throws at request time");
+  }
+}

--- a/tests/Aarogya.Api.Tests/UserProfileServiceTests.cs
+++ b/tests/Aarogya.Api.Tests/UserProfileServiceTests.cs
@@ -69,6 +69,37 @@ public sealed class UserProfileServiceTests
     unitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
   }
 
+  [Theory]
+  [InlineData(true)]
+  [InlineData(false)]
+  public async Task GetCurrentUserAsync_ShouldReportAadhaarVerified_BasedOnReferenceTokenAsync(bool hasToken)
+  {
+    var user = new User
+    {
+      Id = Guid.NewGuid(),
+      ExternalAuthId = "seed-PATIENT-1",
+      Role = UserRole.Patient,
+      FirstName = "Jane",
+      LastName = "Doe",
+      Email = "jane@aarogya.dev",
+      AadhaarRefToken = hasToken ? Guid.NewGuid() : null
+    };
+
+    var repository = new Mock<IUserRepository>();
+    repository.Setup(x => x.GetByExternalAuthIdAsync("seed-PATIENT-1", It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+    var service = new UserProfileService(
+      repository.Object,
+      Mock.Of<IUnitOfWork>(),
+      Mock.Of<IAadhaarVaultService>(),
+      Mock.Of<IAuditLoggingService>(),
+      new FixedUtcClock(new DateTimeOffset(2026, 2, 20, 9, 0, 0, TimeSpan.Zero)));
+
+    var response = await service.GetCurrentUserAsync("seed-PATIENT-1", CancellationToken.None);
+
+    response.AadhaarVerified.Should().Be(hasToken);
+  }
+
   [Fact]
   public async Task GetCurrentUserAsync_ShouldThrow_WhenUserNotFoundAsync()
   {

--- a/tests/Aarogya.Api.Tests/UsersControllerTests.cs
+++ b/tests/Aarogya.Api.Tests/UsersControllerTests.cs
@@ -37,7 +37,8 @@ public sealed class UsersControllerTests
       new DateOnly(1995, 6, 5),
       null,
       "approved",
-      ["Patient"]);
+      ["Patient"],
+      false);
 
     var userProfileService = new Mock<IUserProfileService>();
     userProfileService.Setup(x => x.GetCurrentUserAsync("seed-PATIENT-1", It.IsAny<CancellationToken>())).ReturnsAsync(response);


### PR DESCRIPTION
Fixes the backend half of the settings-page bugs.

## Consent upsert 500 (Closes #274)

`UpsertConsentRequest` declared `[property: MaxLength(80)]` on a positional record. MVC validates record types through their **constructor parameters** and throws `InvalidOperationException` (`ThrowIfRecordTypeHasValidationOnProperties`) at request time when a validation attribute targets the property instead — so every `PUT /api/v1/consents/{purpose}` returned 500, and the settings consent toggles optimistically flipped and then snapped back.

Fix: move the attribute to the constructor parameter. A new convention test (`RequestContractConventionTests`) scans every `Features` request record for property-targeted `ValidationAttribute`s so this class of bug can't ship again (unit tests call controllers directly and never run MVC model validation, which is how this one slipped through).

## Profile now reports Aadhaar verification status

`UserProfileResponse` never included Aadhaar status, but the frontend settings badge reads `profile.aadhaarVerified` — it was always `undefined`, so the badge showed **Not Verified** even after a successful verification (see AarogyaFrontend#131 / secondary of AarogyaFrontend#168). Verification is already persisted as `User.AadhaarRefToken`, so this adds `AadhaarVerified = AadhaarRefToken is not null` to the response. The cached profile decorator already evicts on verify, so the field is fresh immediately after verification.

## Verification

- 654/654 Api.Tests pass, including new `AadhaarVerified` mapping tests and the convention guard
- `dotnet format --verify-no-changes` clean